### PR TITLE
fix(releases): add missing repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "explorer-network-connectors",
   "version": "0.1.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openscan-explorer/explorer-network-connectors"
+  },
   "type": "module",
   "scripts": {
     "build": "tsc -p tsconfig.json",


### PR DESCRIPTION
# Summary
Adds repository.url to package.json so npm's provenance verification matches the GitHub repository. 
Fixes a GitHub action error Publishing via Trusted Publishing (OIDC) failed with E422 because package.json lacked a repository URL that matched the provenance bundle from GitHub Actions.