### PR TITLE
Add Solana Network Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openscan/network-connectors",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openscan/network-connectors",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "devDependencies": {
         "@biomejs/biome": "2.3.7",
         "@tsconfig/node24": "^24.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openscan/network-connectors",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/openscan-explorer/network-connectors"

--- a/src/RpcClientTypes.ts
+++ b/src/RpcClientTypes.ts
@@ -18,3 +18,17 @@ export interface JsonRpcResponse<T = any> {
     data?: any;
   };
 }
+
+/**
+ * JSON-RPC 2.0 notification (server-pushed)
+ * Used for WebSocket subscription notifications (e.g., Solana pubsub)
+ */
+// biome-ignore lint/suspicious/noExplicitAny: subscription payloads vary by method
+export interface JsonRpcNotification<T = any> {
+  jsonrpc: "2.0";
+  method: string;
+  params: {
+    subscription: number;
+    result: T;
+  };
+}

--- a/src/WebSocketRpcClient.ts
+++ b/src/WebSocketRpcClient.ts
@@ -7,6 +7,12 @@ interface PendingRequest<T> {
   timer: ReturnType<typeof setTimeout>;
 }
 
+interface SubscriptionHandler {
+  // biome-ignore lint/suspicious/noExplicitAny: subscription payloads vary by method
+  callback: (data: any) => void;
+  errorHandler?: (error: Error) => void;
+}
+
 interface WebSocketRpcClientOptions {
   /** Request timeout in milliseconds (default: 30000) */
   requestTimeoutMs?: number;
@@ -24,6 +30,7 @@ export class WebSocketRpcClient implements JsonRpcTransport {
   private ws: WebSocket | null = null;
   // biome-ignore lint/suspicious/noExplicitAny: pending requests hold generic resolve/reject
   private pendingRequests: Map<number, PendingRequest<any>> = new Map();
+  private subscriptionHandlers: Map<number, SubscriptionHandler> = new Map();
   private connectPromise: Promise<void> | null = null;
   private requestTimeoutMs: number;
   private maxReconnectRetries: number;
@@ -76,6 +83,44 @@ export class WebSocketRpcClient implements JsonRpcTransport {
         );
       }
     });
+  }
+
+  /**
+   * Subscribe to server-pushed notifications
+   * Sends a subscribe request via call(), then registers a handler for incoming notifications
+   *
+   * @param subscribeMethod - The RPC method to subscribe (e.g., "slotSubscribe")
+   * @param unsubscribeMethod - The RPC method to unsubscribe (e.g., "slotUnsubscribe")
+   * @param params - Parameters for the subscribe call
+   * @param callback - Handler invoked for each notification payload
+   * @param errorHandler - Optional handler invoked on connection loss
+   * @returns Object with subscriptionId and unsubscribe() function
+   */
+  async subscribe<T>(
+    subscribeMethod: string,
+    unsubscribeMethod: string,
+    // biome-ignore lint/suspicious/noExplicitAny: subscription params vary by method
+    params: any[],
+    callback: (data: T) => void,
+    errorHandler?: (error: Error) => void,
+  ): Promise<{ subscriptionId: number; unsubscribe: () => Promise<boolean> }> {
+    const subscriptionId = await this.call<number>(subscribeMethod, params);
+
+    this.subscriptionHandlers.set(subscriptionId, {
+      callback,
+      errorHandler,
+    });
+
+    const unsubscribe = async (): Promise<boolean> => {
+      this.subscriptionHandlers.delete(subscriptionId);
+      try {
+        return await this.call<boolean>(unsubscribeMethod, [subscriptionId]);
+      } catch {
+        return false;
+      }
+    };
+
+    return { subscriptionId, unsubscribe };
   }
 
   getUrl(): string {
@@ -186,10 +231,20 @@ export class WebSocketRpcClient implements JsonRpcTransport {
   private setupMessageHandler(ws: WebSocket): void {
     ws.onmessage = (event: MessageEvent) => {
       try {
-        const response: JsonRpcResponse = JSON.parse(String(event.data));
+        const data = JSON.parse(String(event.data));
 
+        // Subscription notification: has method + params.subscription, no id
+        if (data.id == null && data.method && data.params?.subscription != null) {
+          const handler = this.subscriptionHandlers.get(data.params.subscription);
+          if (handler) {
+            handler.callback(data.params.result);
+          }
+          return;
+        }
+
+        // Standard request/response: has id
+        const response: JsonRpcResponse = data;
         if (response.id == null) {
-          // Server-initiated message (e.g., subscription notification) — ignore for now
           return;
         }
 
@@ -230,6 +285,12 @@ export class WebSocketRpcClient implements JsonRpcTransport {
       pending.reject(error);
       this.pendingRequests.delete(id);
     });
+
+    // Notify subscription error handlers and clear all subscriptions
+    this.subscriptionHandlers.forEach((handler) => {
+      handler.errorHandler?.(error);
+    });
+    this.subscriptionHandlers.clear();
   }
 
   private sleep(ms: number): Promise<void> {

--- a/src/factory/ClientRegistry.ts
+++ b/src/factory/ClientRegistry.ts
@@ -18,6 +18,13 @@ import {
   BITCOIN_SIGNET,
   type BitcoinChainId,
 } from "../networks/bitcoin/BitcoinTypes.js";
+import { SolanaClient } from "../networks/solana/SolanaClient.js";
+import {
+  SOLANA_MAINNET,
+  SOLANA_DEVNET,
+  SOLANA_TESTNET,
+  type SolanaChainId,
+} from "../networks/solana/SolanaTypes.js";
 
 /**
  * Supported EVM chain IDs for the client factory
@@ -41,9 +48,14 @@ export type SupportedChainId =
 export type SupportedBitcoinChainId = BitcoinChainId;
 
 /**
- * All supported network identifiers (EVM chain IDs + Bitcoin CAIP-2 chain IDs)
+ * Supported Solana chain IDs (CAIP-2 format with solana namespace)
  */
-export type SupportedNetwork = SupportedChainId | SupportedBitcoinChainId;
+export type SupportedSolanaChainId = SolanaChainId;
+
+/**
+ * All supported network identifiers (EVM chain IDs + Bitcoin + Solana CAIP-2 chain IDs)
+ */
+export type SupportedNetwork = SupportedChainId | SupportedBitcoinChainId | SupportedSolanaChainId;
 
 /**
  * Constructor type for network clients
@@ -76,11 +88,13 @@ export type ChainIdToClient<T extends SupportedChainId> = T extends 1 | 11155111
 /**
  * Map any network identifier to its specific client type
  */
-export type NetworkToClient<T extends SupportedNetwork> = T extends SupportedBitcoinChainId
-  ? BitcoinClient
-  : T extends SupportedChainId
-    ? ChainIdToClient<T>
-    : NetworkClient;
+export type NetworkToClient<T extends SupportedNetwork> = T extends SupportedSolanaChainId
+  ? SolanaClient
+  : T extends SupportedBitcoinChainId
+    ? BitcoinClient
+    : T extends SupportedChainId
+      ? ChainIdToClient<T>
+      : NetworkClient;
 
 /**
  * Registry mapping EVM chain IDs to their corresponding client constructors
@@ -110,10 +124,26 @@ const BITCOIN_REGISTRY: Record<SupportedBitcoinChainId, typeof BitcoinClient> = 
 };
 
 /**
+ * Registry mapping Solana CAIP-2 chain IDs to the Solana client constructor
+ */
+const SOLANA_REGISTRY: Record<SupportedSolanaChainId, typeof SolanaClient> = {
+  [SOLANA_MAINNET]: SolanaClient,
+  [SOLANA_DEVNET]: SolanaClient,
+  [SOLANA_TESTNET]: SolanaClient,
+};
+
+/**
  * Check if a network identifier is a Bitcoin CAIP-2 chain ID
  */
 function isBitcoinNetwork(network: SupportedNetwork): network is SupportedBitcoinChainId {
   return typeof network === "string" && network.startsWith("bip122:");
+}
+
+/**
+ * Check if a network identifier is a Solana CAIP-2 chain ID
+ */
+function isSolanaNetwork(network: SupportedNetwork): network is SupportedSolanaChainId {
+  return typeof network === "string" && network.startsWith("solana:");
 }
 
 /**
@@ -166,18 +196,30 @@ export class ClientFactory {
    */
   static createClient(chainId: SupportedBitcoinChainId, config: StrategyConfig): BitcoinClient;
   /**
+   * Create a Solana client (CAIP-2 chain ID)
+   */
+  static createClient(chainId: SupportedSolanaChainId, config: StrategyConfig): SolanaClient;
+  /**
    * Create a network client for any supported network
    */
   static createClient(network: SupportedNetwork, config: StrategyConfig): NetworkClient;
   /**
    * Create a network client for the specified network identifier
    *
-   * @param network - The network identifier (EVM chain ID or Bitcoin CAIP-2 chain ID)
+   * @param network - The network identifier (EVM chain ID, Bitcoin or Solana CAIP-2 chain ID)
    * @param config - Strategy configuration with RPC URLs and strategy type
    * @returns NetworkClient instance for the specified network
    * @throws Error if the network is not supported
    */
   static createClient(network: SupportedNetwork, config: StrategyConfig): NetworkClient {
+    if (isSolanaNetwork(network)) {
+      const ClientClass = SOLANA_REGISTRY[network];
+      if (!ClientClass) {
+        throw new Error(`Unsupported Solana network: ${network}`);
+      }
+      return new ClientClass(config);
+    }
+
     if (isBitcoinNetwork(network)) {
       const ClientClass = BITCOIN_REGISTRY[network];
       if (!ClientClass) {
@@ -197,9 +239,9 @@ export class ClientFactory {
    * Create a type-specific network client for the specified network
    * Automatically infers the correct client type based on the network identifier
    *
-   * @param network - The network identifier (EVM chain ID or Bitcoin CAIP-2 chain ID)
+   * @param network - The network identifier (EVM chain ID, Bitcoin or Solana CAIP-2 chain ID)
    * @param config - Strategy configuration with RPC URLs and strategy type
-   * @returns Typed client instance (e.g., BitcoinClient for BITCOIN_MAINNET, EthereumClient for 1)
+   * @returns Typed client instance (e.g., SolanaClient for SOLANA_MAINNET, BitcoinClient for BITCOIN_MAINNET)
    * @throws Error if the network is not supported
    */
   static createTypedClient<T extends SupportedNetwork>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -297,11 +297,71 @@ export type {
   BtcBlockFilter,
 } from "./networks/bitcoin/BitcoinTypes.js";
 
+// Solana (CAIP-2 Chain IDs: solana:*)
+export { SolanaClient } from "./networks/solana/SolanaClient.js";
+export {
+  SOLANA_MAINNET,
+  SOLANA_DEVNET,
+  SOLANA_TESTNET,
+} from "./networks/solana/SolanaTypes.js";
+export type {
+  SolanaChainId,
+  Commitment as SolCommitment,
+  Encoding as SolEncoding,
+  SolRpcResponse,
+  SolAccountInfo,
+  SolKeyedAccount,
+  SolTokenAmount,
+  SolTokenAccount,
+  SolTokenLargestAccount,
+  SolTransaction,
+  SolTransactionData,
+  SolTransactionMessage,
+  SolTransactionMeta,
+  SolInnerInstruction,
+  SolTokenBalance,
+  SolLoadedAddresses,
+  SolReturnData,
+  SolBlock,
+  SolReward,
+  SolVersion,
+  SolEpochInfo,
+  SolEpochSchedule,
+  SolInflationGovernor,
+  SolInflationRate,
+  SolInflationReward,
+  SolSupply,
+  SolVoteAccount,
+  SolClusterNode,
+  SolPerfSample,
+  SolBlockProduction,
+  SolHighestSnapshotSlot,
+  SolPrioritizationFee,
+  SolSignatureStatus,
+  SolSignatureInfo,
+  SolStakeActivation,
+  SolLeaderSchedule,
+  SolLargestAccount,
+  SolBlockCommitment,
+  SolLatestBlockhash,
+  SolSimulateTransactionResult,
+  SolAccountNotification,
+  SolProgramNotification,
+  SolLogsNotification,
+  SolSignatureNotification,
+  SolSlotNotification,
+  SolSlotsUpdatesNotification,
+  SolRootNotification,
+  SolBlockNotification,
+  SolVoteNotification,
+} from "./networks/solana/SolanaTypes.js";
+
 // Client Factory (Chain ID-based instantiation)
 export { ClientFactory } from "./factory/ClientRegistry.js";
 export type {
   SupportedChainId,
   SupportedBitcoinChainId,
+  SupportedSolanaChainId,
   SupportedNetwork,
   ClientConstructor,
   ChainIdToClient,
@@ -328,3 +388,4 @@ export type { JsonRpcTransport } from "./JsonRpcTransport.js";
 export { createTransport } from "./JsonRpcTransport.js";
 export { WebSocketRpcClient } from "./WebSocketRpcClient.js";
 export { RpcClient } from "./RpcClient.js";
+export type { JsonRpcNotification } from "./RpcClientTypes.js";

--- a/src/networks/solana/SolanaClient.ts
+++ b/src/networks/solana/SolanaClient.ts
@@ -1,0 +1,881 @@
+/**
+ * Solana RPC Client
+ *
+ * Provides typed methods for all Solana JSON-RPC API calls and WebSocket subscriptions.
+ * Supports mainnet-beta, devnet, and testnet clusters.
+ *
+ * HTTP methods use the configured strategy (fallback, parallel, race) via this.execute().
+ * Subscription methods use a lazily-created WebSocketRpcClient from the first wss:// URL in rpcUrls.
+ * The subscription WebSocket is independent of the strategy — updateStrategy() does not affect it.
+ *
+ * @see https://solana.com/docs/rpc
+ */
+
+import { NetworkClient } from "../../NetworkClient.js";
+import { WebSocketRpcClient } from "../../WebSocketRpcClient.js";
+import type { StrategyConfig } from "../../strategies/requestStrategy.js";
+import type { StrategyResult } from "../../strategies/strategiesTypes.js";
+import type {
+  Commitment,
+  SolAccountInfo,
+  SolAccountNotification,
+  SolAccountSubscribeConfig,
+  SolBlock,
+  SolBlockCommitment,
+  SolBlockNotification,
+  SolBlockProduction,
+  SolBlockSubscribeConfig,
+  SolClusterNode,
+  SolEpochInfo,
+  SolEpochSchedule,
+  SolGetAccountInfoConfig,
+  SolGetBlockConfig,
+  SolGetBlockProductionConfig,
+  SolGetInflationRewardConfig,
+  SolGetLargestAccountsConfig,
+  SolGetLeaderScheduleConfig,
+  SolGetProgramAccountsConfig,
+  SolGetSignatureStatusesConfig,
+  SolGetSignaturesConfig,
+  SolGetSupplyConfig,
+  SolGetTokenAccountsConfig,
+  SolGetTransactionConfig,
+  SolGetVoteAccountsConfig,
+  SolHighestSnapshotSlot,
+  SolInflationGovernor,
+  SolInflationRate,
+  SolInflationReward,
+  SolKeyedAccount,
+  SolLargestAccount,
+  SolLatestBlockhash,
+  SolLeaderSchedule,
+  SolLogsNotification,
+  SolLogsSubscribeConfig,
+  SolPerfSample,
+  SolPrioritizationFee,
+  SolProgramNotification,
+  SolProgramSubscribeConfig,
+  SolRootNotification,
+  SolRpcResponse,
+  SolSendTransactionConfig,
+  SolSignatureInfo,
+  SolSignatureNotification,
+  SolSignatureSubscribeConfig,
+  SolSignatureStatus,
+  SolSimulateTransactionConfig,
+  SolSimulateTransactionResult,
+  SolSlotNotification,
+  SolSlotsUpdatesNotification,
+  SolStakeActivation,
+  SolSupply,
+  SolTokenAccount,
+  SolTokenAccountFilter,
+  SolTokenAmount,
+  SolTokenLargestAccount,
+  SolTransaction,
+  SolVersion,
+  SolVoteAccount,
+  SolVoteNotification,
+} from "./SolanaTypes.js";
+
+export class SolanaClient extends NetworkClient {
+  private subscriptionWs: WebSocketRpcClient | null = null;
+  private subscriptionWsUrl: string | null;
+
+  constructor(config: StrategyConfig) {
+    super(config);
+    this.subscriptionWsUrl =
+      config.rpcUrls.find((url) => url.startsWith("wss://") || url.startsWith("ws://")) ?? null;
+  }
+
+  private getSubscriptionWs(): WebSocketRpcClient {
+    if (!this.subscriptionWsUrl) {
+      throw new Error("Solana subscriptions require at least one ws:// or wss:// URL in rpcUrls");
+    }
+    if (!this.subscriptionWs) {
+      this.subscriptionWs = new WebSocketRpcClient(this.subscriptionWsUrl);
+    }
+    return this.subscriptionWs;
+  }
+
+  // ─── Account / State Methods ───
+
+  /**
+   * Returns all information associated with the account of provided Pubkey
+   */
+  async getAccountInfo(
+    pubkey: string,
+    config?: SolGetAccountInfoConfig,
+  ): Promise<StrategyResult<SolRpcResponse<SolAccountInfo | null>>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [pubkey];
+    if (config) params.push(config);
+    return this.execute<SolRpcResponse<SolAccountInfo | null>>("getAccountInfo", params);
+  }
+
+  /**
+   * Returns the lamport balance of the account of provided Pubkey
+   */
+  async getBalance(
+    pubkey: string,
+    config?: { commitment?: Commitment; minContextSlot?: number },
+  ): Promise<StrategyResult<SolRpcResponse<number>>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [pubkey];
+    if (config) params.push(config);
+    return this.execute<SolRpcResponse<number>>("getBalance", params);
+  }
+
+  /**
+   * Returns the account information for a list of Pubkeys
+   */
+  async getMultipleAccounts(
+    pubkeys: string[],
+    config?: SolGetAccountInfoConfig,
+  ): Promise<StrategyResult<SolRpcResponse<(SolAccountInfo | null)[]>>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [pubkeys];
+    if (config) params.push(config);
+    return this.execute<SolRpcResponse<(SolAccountInfo | null)[]>>("getMultipleAccounts", params);
+  }
+
+  /**
+   * Returns all accounts owned by the provided program Pubkey
+   */
+  async getProgramAccounts(
+    programId: string,
+    config?: SolGetProgramAccountsConfig,
+  ): Promise<StrategyResult<SolKeyedAccount[]>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [programId];
+    if (config) params.push(config);
+    return this.execute<SolKeyedAccount[]>("getProgramAccounts", params);
+  }
+
+  /**
+   * Returns the token balance of an SPL Token account
+   */
+  async getTokenAccountBalance(
+    pubkey: string,
+    commitment?: Commitment,
+  ): Promise<StrategyResult<SolRpcResponse<SolTokenAmount>>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [pubkey];
+    if (commitment) params.push({ commitment });
+    return this.execute<SolRpcResponse<SolTokenAmount>>("getTokenAccountBalance", params);
+  }
+
+  /**
+   * Returns all SPL Token accounts by approved delegate
+   */
+  async getTokenAccountsByDelegate(
+    delegate: string,
+    filter: SolTokenAccountFilter,
+    config?: SolGetTokenAccountsConfig,
+  ): Promise<StrategyResult<SolRpcResponse<SolTokenAccount[]>>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [delegate, filter];
+    if (config) params.push(config);
+    return this.execute<SolRpcResponse<SolTokenAccount[]>>("getTokenAccountsByDelegate", params);
+  }
+
+  /**
+   * Returns all SPL Token accounts by token owner
+   */
+  async getTokenAccountsByOwner(
+    owner: string,
+    filter: SolTokenAccountFilter,
+    config?: SolGetTokenAccountsConfig,
+  ): Promise<StrategyResult<SolRpcResponse<SolTokenAccount[]>>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [owner, filter];
+    if (config) params.push(config);
+    return this.execute<SolRpcResponse<SolTokenAccount[]>>("getTokenAccountsByOwner", params);
+  }
+
+  /**
+   * Returns the 20 largest accounts of a particular SPL Token type
+   */
+  async getTokenLargestAccounts(
+    mint: string,
+    commitment?: Commitment,
+  ): Promise<StrategyResult<SolRpcResponse<SolTokenLargestAccount[]>>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [mint];
+    if (commitment) params.push({ commitment });
+    return this.execute<SolRpcResponse<SolTokenLargestAccount[]>>(
+      "getTokenLargestAccounts",
+      params,
+    );
+  }
+
+  /**
+   * Returns the total supply of an SPL Token type
+   */
+  async getTokenSupply(
+    mint: string,
+    commitment?: Commitment,
+  ): Promise<StrategyResult<SolRpcResponse<SolTokenAmount>>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [mint];
+    if (commitment) params.push({ commitment });
+    return this.execute<SolRpcResponse<SolTokenAmount>>("getTokenSupply", params);
+  }
+
+  /**
+   * Returns the 20 largest accounts, by lamport balance
+   */
+  async getLargestAccounts(
+    config?: SolGetLargestAccountsConfig,
+  ): Promise<StrategyResult<SolRpcResponse<SolLargestAccount[]>>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [];
+    if (config) params.push(config);
+    return this.execute<SolRpcResponse<SolLargestAccount[]>>("getLargestAccounts", params);
+  }
+
+  /**
+   * Returns minimum balance required to make account rent exempt
+   */
+  async getMinimumBalanceForRentExemption(
+    dataLength: number,
+    commitment?: Commitment,
+  ): Promise<StrategyResult<number>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [dataLength];
+    if (commitment) params.push({ commitment });
+    return this.execute<number>("getMinimumBalanceForRentExemption", params);
+  }
+
+  /**
+   * Returns the stake minimum delegation, in lamports
+   */
+  async getStakeMinimumDelegation(
+    commitment?: Commitment,
+  ): Promise<StrategyResult<SolRpcResponse<number>>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [];
+    if (commitment) params.push({ commitment });
+    return this.execute<SolRpcResponse<number>>("getStakeMinimumDelegation", params);
+  }
+
+  // ─── Block / Slot Methods ───
+
+  /**
+   * Returns identity and transaction information about a confirmed block
+   */
+  async getBlock(
+    slot: number,
+    config?: SolGetBlockConfig,
+  ): Promise<StrategyResult<SolBlock | null>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [slot];
+    if (config) params.push(config);
+    return this.execute<SolBlock | null>("getBlock", params);
+  }
+
+  /**
+   * Returns the current block height
+   */
+  async getBlockHeight(commitment?: Commitment): Promise<StrategyResult<number>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [];
+    if (commitment) params.push({ commitment });
+    return this.execute<number>("getBlockHeight", params);
+  }
+
+  /**
+   * Returns recent block production information
+   */
+  async getBlockProduction(
+    config?: SolGetBlockProductionConfig,
+  ): Promise<StrategyResult<SolRpcResponse<SolBlockProduction>>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [];
+    if (config) params.push(config);
+    return this.execute<SolRpcResponse<SolBlockProduction>>("getBlockProduction", params);
+  }
+
+  /**
+   * Returns commitment for particular block
+   */
+  async getBlockCommitment(slot: number): Promise<StrategyResult<SolBlockCommitment>> {
+    return this.execute<SolBlockCommitment>("getBlockCommitment", [slot]);
+  }
+
+  /**
+   * Returns a list of confirmed blocks between two slots
+   */
+  async getBlocks(
+    startSlot: number,
+    endSlot?: number,
+    commitment?: Commitment,
+  ): Promise<StrategyResult<number[]>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [startSlot];
+    if (endSlot !== undefined) params.push(endSlot);
+    if (commitment) params.push({ commitment });
+    return this.execute<number[]>("getBlocks", params);
+  }
+
+  /**
+   * Returns a list of confirmed blocks starting at the given slot
+   */
+  async getBlocksWithLimit(
+    startSlot: number,
+    limit: number,
+    commitment?: Commitment,
+  ): Promise<StrategyResult<number[]>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [startSlot, limit];
+    if (commitment) params.push({ commitment });
+    return this.execute<number[]>("getBlocksWithLimit", params);
+  }
+
+  /**
+   * Returns the estimated production time of a block
+   */
+  async getBlockTime(slot: number): Promise<StrategyResult<number | null>> {
+    return this.execute<number | null>("getBlockTime", [slot]);
+  }
+
+  /**
+   * Returns the current slot
+   */
+  async getSlot(commitment?: Commitment): Promise<StrategyResult<number>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [];
+    if (commitment) params.push({ commitment });
+    return this.execute<number>("getSlot", params);
+  }
+
+  /**
+   * Returns the current slot leader
+   */
+  async getSlotLeader(commitment?: Commitment): Promise<StrategyResult<string>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [];
+    if (commitment) params.push({ commitment });
+    return this.execute<string>("getSlotLeader", params);
+  }
+
+  /**
+   * Returns the slot leaders for a given slot range
+   */
+  async getSlotLeaders(startSlot: number, limit: number): Promise<StrategyResult<string[]>> {
+    return this.execute<string[]>("getSlotLeaders", [startSlot, limit]);
+  }
+
+  // ─── Transaction Methods ───
+
+  /**
+   * Returns transaction details for a confirmed transaction
+   */
+  async getTransaction(
+    signature: string,
+    config?: SolGetTransactionConfig,
+  ): Promise<StrategyResult<SolTransaction | null>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [signature];
+    if (config) params.push(config);
+    return this.execute<SolTransaction | null>("getTransaction", params);
+  }
+
+  /**
+   * Returns confirmed signatures for transactions involving an address
+   */
+  async getSignaturesForAddress(
+    address: string,
+    config?: SolGetSignaturesConfig,
+  ): Promise<StrategyResult<SolSignatureInfo[]>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [address];
+    if (config) params.push(config);
+    return this.execute<SolSignatureInfo[]>("getSignaturesForAddress", params);
+  }
+
+  /**
+   * Returns the statuses of a list of signatures
+   */
+  async getSignatureStatuses(
+    signatures: string[],
+    config?: SolGetSignatureStatusesConfig,
+  ): Promise<StrategyResult<SolRpcResponse<(SolSignatureStatus | null)[]>>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [signatures];
+    if (config) params.push(config);
+    return this.execute<SolRpcResponse<(SolSignatureStatus | null)[]>>(
+      "getSignatureStatuses",
+      params,
+    );
+  }
+
+  /**
+   * Submits a signed transaction to the cluster for processing
+   */
+  async sendTransaction(
+    encodedTransaction: string,
+    config?: SolSendTransactionConfig,
+  ): Promise<StrategyResult<string>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [encodedTransaction];
+    if (config) params.push(config);
+    return this.execute<string>("sendTransaction", params);
+  }
+
+  /**
+   * Simulate sending a transaction
+   */
+  async simulateTransaction(
+    encodedTransaction: string,
+    config?: SolSimulateTransactionConfig,
+  ): Promise<StrategyResult<SolRpcResponse<SolSimulateTransactionResult>>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [encodedTransaction];
+    if (config) params.push(config);
+    return this.execute<SolRpcResponse<SolSimulateTransactionResult>>(
+      "simulateTransaction",
+      params,
+    );
+  }
+
+  /**
+   * Returns a list of prioritization fees from recent blocks
+   */
+  async getRecentPrioritizationFees(
+    addresses?: string[],
+  ): Promise<StrategyResult<SolPrioritizationFee[]>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [];
+    if (addresses) params.push(addresses);
+    return this.execute<SolPrioritizationFee[]>("getRecentPrioritizationFees", params);
+  }
+
+  /**
+   * Returns whether a blockhash is still valid
+   */
+  async isBlockhashValid(
+    blockhash: string,
+    commitment?: Commitment,
+  ): Promise<StrategyResult<SolRpcResponse<boolean>>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [blockhash];
+    if (commitment) params.push({ commitment });
+    return this.execute<SolRpcResponse<boolean>>("isBlockhashValid", params);
+  }
+
+  /**
+   * Returns a recent block hash and the associated fee schedule
+   */
+  async getLatestBlockhash(
+    commitment?: Commitment,
+  ): Promise<StrategyResult<SolRpcResponse<SolLatestBlockhash>>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [];
+    if (commitment) params.push({ commitment });
+    return this.execute<SolRpcResponse<SolLatestBlockhash>>("getLatestBlockhash", params);
+  }
+
+  /**
+   * Returns the fee the network will charge for a particular message
+   */
+  async getFeeForMessage(
+    message: string,
+    commitment?: Commitment,
+  ): Promise<StrategyResult<SolRpcResponse<number | null>>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [message];
+    if (commitment) params.push({ commitment });
+    return this.execute<SolRpcResponse<number | null>>("getFeeForMessage", params);
+  }
+
+  // ─── Cluster / Network Methods ───
+
+  /**
+   * Returns information about all the nodes participating in the cluster
+   */
+  async getClusterNodes(): Promise<StrategyResult<SolClusterNode[]>> {
+    return this.execute<SolClusterNode[]>("getClusterNodes", []);
+  }
+
+  /**
+   * Returns information about the current epoch
+   */
+  async getEpochInfo(commitment?: Commitment): Promise<StrategyResult<SolEpochInfo>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [];
+    if (commitment) params.push({ commitment });
+    return this.execute<SolEpochInfo>("getEpochInfo", params);
+  }
+
+  /**
+   * Returns the epoch schedule information from this cluster's genesis config
+   */
+  async getEpochSchedule(): Promise<StrategyResult<SolEpochSchedule>> {
+    return this.execute<SolEpochSchedule>("getEpochSchedule", []);
+  }
+
+  /**
+   * Returns the genesis hash
+   */
+  async getGenesisHash(): Promise<StrategyResult<string>> {
+    return this.execute<string>("getGenesisHash", []);
+  }
+
+  /**
+   * Returns the current health of the node ("ok" if healthy)
+   */
+  async getHealth(): Promise<StrategyResult<string>> {
+    return this.execute<string>("getHealth", []);
+  }
+
+  /**
+   * Returns the highest slot information that the node has snapshots for
+   */
+  async getHighestSnapshotSlot(): Promise<StrategyResult<SolHighestSnapshotSlot>> {
+    return this.execute<SolHighestSnapshotSlot>("getHighestSnapshotSlot", []);
+  }
+
+  /**
+   * Returns the identity pubkey for the current node
+   */
+  async getIdentity(): Promise<StrategyResult<{ identity: string }>> {
+    return this.execute<{ identity: string }>("getIdentity", []);
+  }
+
+  /**
+   * Returns the current inflation governor
+   */
+  async getInflationGovernor(
+    commitment?: Commitment,
+  ): Promise<StrategyResult<SolInflationGovernor>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [];
+    if (commitment) params.push({ commitment });
+    return this.execute<SolInflationGovernor>("getInflationGovernor", params);
+  }
+
+  /**
+   * Returns the specific inflation values for the current epoch
+   */
+  async getInflationRate(): Promise<StrategyResult<SolInflationRate>> {
+    return this.execute<SolInflationRate>("getInflationRate", []);
+  }
+
+  /**
+   * Returns the inflation / staking reward for a list of addresses for an epoch
+   */
+  async getInflationReward(
+    addresses: string[],
+    config?: SolGetInflationRewardConfig,
+  ): Promise<StrategyResult<(SolInflationReward | null)[]>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [addresses];
+    if (config) params.push(config);
+    return this.execute<(SolInflationReward | null)[]>("getInflationReward", params);
+  }
+
+  /**
+   * Returns the leader schedule for an epoch
+   */
+  async getLeaderSchedule(
+    slot?: number | null,
+    config?: SolGetLeaderScheduleConfig,
+  ): Promise<StrategyResult<SolLeaderSchedule | null>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [];
+    if (slot !== undefined) params.push(slot);
+    if (config) params.push(config);
+    return this.execute<SolLeaderSchedule | null>("getLeaderSchedule", params);
+  }
+
+  /**
+   * Returns the max slot seen from retransmit stage
+   */
+  async getMaxRetransmitSlot(): Promise<StrategyResult<number>> {
+    return this.execute<number>("getMaxRetransmitSlot", []);
+  }
+
+  /**
+   * Returns the max slot seen from after shred insert
+   */
+  async getMaxShredInsertSlot(): Promise<StrategyResult<number>> {
+    return this.execute<number>("getMaxShredInsertSlot", []);
+  }
+
+  /**
+   * Returns a list of recent performance samples
+   */
+  async getRecentPerformanceSamples(limit?: number): Promise<StrategyResult<SolPerfSample[]>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [];
+    if (limit !== undefined) params.push(limit);
+    return this.execute<SolPerfSample[]>("getRecentPerformanceSamples", params);
+  }
+
+  /**
+   * Returns information about the current supply
+   */
+  async getSupply(config?: SolGetSupplyConfig): Promise<StrategyResult<SolRpcResponse<SolSupply>>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [];
+    if (config) params.push(config);
+    return this.execute<SolRpcResponse<SolSupply>>("getSupply", params);
+  }
+
+  /**
+   * Returns the current transaction count
+   */
+  async getTransactionCount(commitment?: Commitment): Promise<StrategyResult<number>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [];
+    if (commitment) params.push({ commitment });
+    return this.execute<number>("getTransactionCount", params);
+  }
+
+  /**
+   * Returns the current Solana version running on the node
+   */
+  async getVersion(): Promise<StrategyResult<SolVersion>> {
+    return this.execute<SolVersion>("getVersion", []);
+  }
+
+  /**
+   * Returns the account info and associated stake for all the voting accounts
+   */
+  async getVoteAccounts(
+    config?: SolGetVoteAccountsConfig,
+  ): Promise<StrategyResult<{ current: SolVoteAccount[]; delinquent: SolVoteAccount[] }>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [];
+    if (config) params.push(config);
+    return this.execute<{ current: SolVoteAccount[]; delinquent: SolVoteAccount[] }>(
+      "getVoteAccounts",
+      params,
+    );
+  }
+
+  /**
+   * Returns epoch activation information for a stake account
+   */
+  async getStakeActivation(
+    pubkey: string,
+    config?: { commitment?: Commitment; epoch?: number; minContextSlot?: number },
+  ): Promise<StrategyResult<SolStakeActivation>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [pubkey];
+    if (config) params.push(config);
+    return this.execute<SolStakeActivation>("getStakeActivation", params);
+  }
+
+  /**
+   * Returns the lowest slot that the node has information about in its ledger
+   */
+  async minimumLedgerSlot(): Promise<StrategyResult<number>> {
+    return this.execute<number>("minimumLedgerSlot", []);
+  }
+
+  /**
+   * Requests an airdrop of lamports to a Pubkey
+   */
+  async requestAirdrop(
+    pubkey: string,
+    lamports: number,
+    commitment?: Commitment,
+  ): Promise<StrategyResult<string>> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [pubkey, lamports];
+    if (commitment) params.push({ commitment });
+    return this.execute<string>("requestAirdrop", params);
+  }
+
+  /**
+   * Returns the first available block after a given slot
+   */
+  async getFirstAvailableBlock(): Promise<StrategyResult<number>> {
+    return this.execute<number>("getFirstAvailableBlock", []);
+  }
+
+  // ─── Subscription Methods ───
+
+  /**
+   * Subscribe to an account to receive notifications when the lamports or data change
+   */
+  async accountSubscribe(
+    pubkey: string,
+    callback: (data: SolRpcResponse<SolAccountNotification>) => void,
+    config?: SolAccountSubscribeConfig,
+    errorHandler?: (error: Error) => void,
+  ): Promise<{ subscriptionId: number; unsubscribe: () => Promise<boolean> }> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [pubkey];
+    if (config) params.push(config);
+    return this.getSubscriptionWs().subscribe<SolRpcResponse<SolAccountNotification>>(
+      "accountSubscribe",
+      "accountUnsubscribe",
+      params,
+      callback,
+      errorHandler,
+    );
+  }
+
+  /**
+   * Subscribe to a program to receive notifications when the lamports or data for an
+   * account owned by the given program changes
+   */
+  async programSubscribe(
+    programId: string,
+    callback: (data: SolRpcResponse<SolProgramNotification>) => void,
+    config?: SolProgramSubscribeConfig,
+    errorHandler?: (error: Error) => void,
+  ): Promise<{ subscriptionId: number; unsubscribe: () => Promise<boolean> }> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [programId];
+    if (config) params.push(config);
+    return this.getSubscriptionWs().subscribe<SolRpcResponse<SolProgramNotification>>(
+      "programSubscribe",
+      "programUnsubscribe",
+      params,
+      callback,
+      errorHandler,
+    );
+  }
+
+  /**
+   * Subscribe to transaction logging
+   */
+  async logsSubscribe(
+    filter: "all" | "allWithVotes" | { mentions: string[] },
+    callback: (data: SolRpcResponse<SolLogsNotification>) => void,
+    config?: SolLogsSubscribeConfig,
+    errorHandler?: (error: Error) => void,
+  ): Promise<{ subscriptionId: number; unsubscribe: () => Promise<boolean> }> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [filter];
+    if (config) params.push(config);
+    return this.getSubscriptionWs().subscribe<SolRpcResponse<SolLogsNotification>>(
+      "logsSubscribe",
+      "logsUnsubscribe",
+      params,
+      callback,
+      errorHandler,
+    );
+  }
+
+  /**
+   * Subscribe to receive notification when a transaction with the given signature is confirmed
+   */
+  async signatureSubscribe(
+    signature: string,
+    callback: (data: SolRpcResponse<SolSignatureNotification>) => void,
+    config?: SolSignatureSubscribeConfig,
+    errorHandler?: (error: Error) => void,
+  ): Promise<{ subscriptionId: number; unsubscribe: () => Promise<boolean> }> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [signature];
+    if (config) params.push(config);
+    return this.getSubscriptionWs().subscribe<SolRpcResponse<SolSignatureNotification>>(
+      "signatureSubscribe",
+      "signatureUnsubscribe",
+      params,
+      callback,
+      errorHandler,
+    );
+  }
+
+  /**
+   * Subscribe to receive notification anytime a slot is processed by the validator
+   */
+  async slotSubscribe(
+    callback: (data: SolSlotNotification) => void,
+    errorHandler?: (error: Error) => void,
+  ): Promise<{ subscriptionId: number; unsubscribe: () => Promise<boolean> }> {
+    return this.getSubscriptionWs().subscribe<SolSlotNotification>(
+      "slotSubscribe",
+      "slotUnsubscribe",
+      [],
+      callback,
+      errorHandler,
+    );
+  }
+
+  /**
+   * Subscribe to receive a notification from the validator on a variety of updates on every slot
+   */
+  async slotsUpdatesSubscribe(
+    callback: (data: SolSlotsUpdatesNotification) => void,
+    errorHandler?: (error: Error) => void,
+  ): Promise<{ subscriptionId: number; unsubscribe: () => Promise<boolean> }> {
+    return this.getSubscriptionWs().subscribe<SolSlotsUpdatesNotification>(
+      "slotsUpdatesSubscribe",
+      "slotsUpdatesUnsubscribe",
+      [],
+      callback,
+      errorHandler,
+    );
+  }
+
+  /**
+   * Subscribe to receive notification anytime a new root is set by the validator
+   */
+  async rootSubscribe(
+    callback: (data: SolRootNotification) => void,
+    errorHandler?: (error: Error) => void,
+  ): Promise<{ subscriptionId: number; unsubscribe: () => Promise<boolean> }> {
+    return this.getSubscriptionWs().subscribe<SolRootNotification>(
+      "rootSubscribe",
+      "rootUnsubscribe",
+      [],
+      callback,
+      errorHandler,
+    );
+  }
+
+  /**
+   * Subscribe to receive notification anytime a new block is confirmed or finalized
+   */
+  async blockSubscribe(
+    filter: "all" | { mentionsAccountOrProgram: string },
+    callback: (data: SolRpcResponse<SolBlockNotification>) => void,
+    config?: SolBlockSubscribeConfig,
+    errorHandler?: (error: Error) => void,
+  ): Promise<{ subscriptionId: number; unsubscribe: () => Promise<boolean> }> {
+    // biome-ignore lint/suspicious/noExplicitAny: params built conditionally
+    const params: any[] = [filter];
+    if (config) params.push(config);
+    return this.getSubscriptionWs().subscribe<SolRpcResponse<SolBlockNotification>>(
+      "blockSubscribe",
+      "blockUnsubscribe",
+      params,
+      callback,
+      errorHandler,
+    );
+  }
+
+  /**
+   * Subscribe to receive notification anytime a new vote is observed in gossip
+   */
+  async voteSubscribe(
+    callback: (data: SolVoteNotification) => void,
+    errorHandler?: (error: Error) => void,
+  ): Promise<{ subscriptionId: number; unsubscribe: () => Promise<boolean> }> {
+    return this.getSubscriptionWs().subscribe<SolVoteNotification>(
+      "voteSubscribe",
+      "voteUnsubscribe",
+      [],
+      callback,
+      errorHandler,
+    );
+  }
+
+  /**
+   * Close underlying transports including the subscription WebSocket
+   */
+  async close(): Promise<void> {
+    await super.close();
+    if (this.subscriptionWs) {
+      await this.subscriptionWs.close();
+      this.subscriptionWs = null;
+    }
+  }
+}

--- a/src/networks/solana/SolanaTypes.ts
+++ b/src/networks/solana/SolanaTypes.ts
@@ -1,0 +1,606 @@
+/**
+ * Solana RPC Types
+ *
+ * Type definitions for Solana JSON-RPC API responses.
+ * Supports mainnet-beta, devnet, and testnet clusters.
+ *
+ * @see https://solana.com/docs/rpc
+ */
+
+// ─── Chain ID Constants (CAIP-2 format: solana:<first-32-chars-of-genesis-hash>) ───
+
+/**
+ * CAIP-2 chain ID for Solana Mainnet Beta
+ */
+export const SOLANA_MAINNET = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp" as const;
+
+/**
+ * CAIP-2 chain ID for Solana Devnet
+ */
+export const SOLANA_DEVNET = "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1" as const;
+
+/**
+ * CAIP-2 chain ID for Solana Testnet
+ */
+export const SOLANA_TESTNET = "solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z" as const;
+
+/**
+ * Union type of all supported Solana CAIP-2 chain IDs
+ */
+export type SolanaChainId = typeof SOLANA_MAINNET | typeof SOLANA_DEVNET | typeof SOLANA_TESTNET;
+
+// ─── Common Config Types ───
+
+/** Commitment levels for Solana RPC requests */
+export type Commitment = "processed" | "confirmed" | "finalized";
+
+/** Encoding formats for account data */
+export type Encoding = "base58" | "base64" | "base64+zstd" | "jsonParsed";
+
+/** Transaction detail levels for getBlock */
+export type TransactionDetail = "full" | "accounts" | "signatures" | "none";
+
+/** Data slice configuration for account data */
+export interface DataSlice {
+  offset: number;
+  length: number;
+}
+
+/** Wrapped response with context metadata */
+export interface SolRpcResponse<T> {
+  context: {
+    slot: number;
+    apiVersion?: string;
+  };
+  value: T;
+}
+
+// ─── Account Types ───
+
+export interface SolAccountInfo {
+  /** Number of lamports assigned to this account */
+  lamports: number;
+  /** Base-58 encoded pubkey of the program this account has been assigned to */
+  owner: string;
+  /** Data associated with the account, either as encoded string or JSON parsed */
+  // biome-ignore lint/suspicious/noExplicitAny: account data varies by encoding
+  data: string | [string, string] | { program: string; parsed: any; space: number };
+  /** Whether this account contains an executable program */
+  executable: boolean;
+  /** The epoch at which this account will next owe rent */
+  rentEpoch: number;
+  /** The data size of the account */
+  space?: number;
+}
+
+export interface SolKeyedAccount {
+  account: SolAccountInfo;
+  pubkey: string;
+}
+
+// ─── Token Types ───
+
+export interface SolTokenAmount {
+  /** Raw amount as a string */
+  amount: string;
+  /** Number of decimals */
+  decimals: number;
+  /** Token amount as a number (deprecated, may lose precision) */
+  uiAmount: number | null;
+  /** Token amount as a string */
+  uiAmountString: string;
+}
+
+export interface SolTokenAccount {
+  account: SolAccountInfo;
+  pubkey: string;
+}
+
+export interface SolTokenLargestAccount {
+  address: string;
+  amount: string;
+  decimals: number;
+  uiAmount: number | null;
+  uiAmountString: string;
+}
+
+// ─── Transaction Types ───
+
+export interface SolTransaction {
+  /** Slot this transaction was processed in */
+  slot: number;
+  /** The transaction object */
+  transaction: SolTransactionData;
+  /** Transaction metadata */
+  meta: SolTransactionMeta | null;
+  /** The unix timestamp of when the transaction was processed */
+  blockTime: number | null;
+  /** Transaction version ("legacy" or 0) */
+  version?: "legacy" | 0;
+}
+
+export interface SolTransactionData {
+  /** List of base-58 encoded signatures */
+  signatures: string[];
+  /** The transaction message */
+  message: SolTransactionMessage;
+}
+
+export interface SolTransactionMessage {
+  /** List of base-58 encoded public keys used by the transaction */
+  accountKeys: string[] | SolParsedAccountKey[];
+  /** A base-58 encoded hash of a recent block */
+  recentBlockhash: string;
+  /** List of program instructions */
+  // biome-ignore lint/suspicious/noExplicitAny: instruction formats vary by encoding
+  instructions: any[];
+  /** List of address table lookups used by the transaction (v0 transactions) */
+  addressTableLookups?: SolAddressTableLookup[];
+}
+
+export interface SolParsedAccountKey {
+  pubkey: string;
+  writable: boolean;
+  signer: boolean;
+  source?: "transaction" | "lookupTable";
+}
+
+export interface SolAddressTableLookup {
+  accountKey: string;
+  writableIndexes: number[];
+  readonlyIndexes: number[];
+}
+
+export interface SolTransactionMeta {
+  /** Error if transaction failed, null if succeeded */
+  // biome-ignore lint/suspicious/noExplicitAny: error format varies
+  err: any;
+  /** Fee this transaction was charged (in lamports) */
+  fee: number;
+  /** Array of account balances before the transaction was processed */
+  preBalances: number[];
+  /** Array of account balances after the transaction was processed */
+  postBalances: number[];
+  /** List of inner instructions or null if not enabled */
+  innerInstructions: SolInnerInstruction[] | null;
+  /** Log messages from the transaction */
+  logMessages: string[] | null;
+  /** Pre-transaction token balances */
+  preTokenBalances?: SolTokenBalance[];
+  /** Post-transaction token balances */
+  postTokenBalances?: SolTokenBalance[];
+  /** Rewards collected in this transaction */
+  rewards?: SolReward[] | null;
+  /** Addresses loaded from address lookup tables (v0 transactions) */
+  loadedAddresses?: SolLoadedAddresses;
+  /** Return data from the transaction */
+  returnData?: SolReturnData | null;
+  /** Compute units consumed by the transaction */
+  computeUnitsConsumed?: number;
+}
+
+export interface SolInnerInstruction {
+  index: number;
+  // biome-ignore lint/suspicious/noExplicitAny: instruction formats vary by encoding
+  instructions: any[];
+}
+
+export interface SolTokenBalance {
+  accountIndex: number;
+  mint: string;
+  uiTokenAmount: SolTokenAmount;
+  owner?: string;
+  programId?: string;
+}
+
+export interface SolLoadedAddresses {
+  writable: string[];
+  readonly: string[];
+}
+
+export interface SolReturnData {
+  programId: string;
+  data: [string, string];
+}
+
+// ─── Block Types ───
+
+export interface SolBlock {
+  /** The blockhash of this block */
+  blockhash: string;
+  /** The blockhash of this block's parent */
+  previousBlockhash: string;
+  /** The slot index of this block's parent */
+  parentSlot: number;
+  /** Array of transactions in this block */
+  // biome-ignore lint/suspicious/noExplicitAny: transaction format varies by transactionDetails param
+  transactions?: any[];
+  /** Array of transaction signatures in this block */
+  signatures?: string[];
+  /** Array of rewards collected in this block */
+  rewards?: SolReward[];
+  /** Estimated production time as a Unix timestamp */
+  blockTime: number | null;
+  /** The number of blocks beneath this block */
+  blockHeight: number | null;
+}
+
+export interface SolReward {
+  pubkey: string;
+  lamports: number;
+  postBalance: number;
+  rewardType: "fee" | "rent" | "staking" | "voting" | null;
+  commission?: number | null;
+}
+
+// ─── Cluster / Network Types ───
+
+export interface SolVersion {
+  /** Software version of solana-core */
+  "solana-core": string;
+  /** Unique identifier of the current software's feature set */
+  "feature-set": number;
+}
+
+export interface SolEpochInfo {
+  absoluteSlot: number;
+  blockHeight: number;
+  epoch: number;
+  slotIndex: number;
+  slotsInEpoch: number;
+  transactionCount?: number;
+}
+
+export interface SolEpochSchedule {
+  slotsPerEpoch: number;
+  leaderScheduleSlotOffset: number;
+  warmup: boolean;
+  firstNormalEpoch: number;
+  firstNormalSlot: number;
+}
+
+export interface SolInflationGovernor {
+  initial: number;
+  terminal: number;
+  taper: number;
+  foundation: number;
+  foundationTerm: number;
+}
+
+export interface SolInflationRate {
+  total: number;
+  validator: number;
+  foundation: number;
+  epoch: number;
+}
+
+export interface SolInflationReward {
+  epoch: number;
+  effectiveSlot: number;
+  amount: number;
+  postBalance: number;
+  commission?: number | null;
+}
+
+export interface SolSupply {
+  total: number;
+  circulating: number;
+  nonCirculating: number;
+  nonCirculatingAccounts: string[];
+}
+
+export interface SolVoteAccount {
+  votePubkey: string;
+  nodePubkey: string;
+  activatedStake: number;
+  epochVoteAccount: boolean;
+  commission: number;
+  lastVote: number;
+  epochCredits: [number, number, number][];
+  rootSlot?: number;
+}
+
+export interface SolClusterNode {
+  pubkey: string;
+  gossip: string | null;
+  tpu: string | null;
+  rpc: string | null;
+  version: string | null;
+  featureSet: number | null;
+  shredVersion: number | null;
+}
+
+export interface SolPerfSample {
+  slot: number;
+  numTransactions: number;
+  numSlots: number;
+  samplePeriodSecs: number;
+  numNonVoteTransactions?: number;
+}
+
+export interface SolBlockProduction {
+  byIdentity: Record<string, [number, number]>;
+  range: {
+    firstSlot: number;
+    lastSlot: number;
+  };
+}
+
+export interface SolHighestSnapshotSlot {
+  full: number;
+  incremental?: number;
+}
+
+export interface SolPrioritizationFee {
+  slot: number;
+  prioritizationFee: number;
+}
+
+export interface SolSignatureStatus {
+  slot: number;
+  confirmations: number | null;
+  // biome-ignore lint/suspicious/noExplicitAny: error format varies
+  err: any;
+  confirmationStatus: Commitment | null;
+}
+
+export interface SolSignatureInfo {
+  signature: string;
+  slot: number;
+  // biome-ignore lint/suspicious/noExplicitAny: error format varies
+  err: any;
+  memo: string | null;
+  blockTime: number | null;
+  confirmationStatus: Commitment | null;
+}
+
+export interface SolStakeActivation {
+  state: "active" | "inactive" | "activating" | "deactivating";
+  active: number;
+  inactive: number;
+}
+
+export interface SolLeaderSchedule {
+  [validatorIdentity: string]: number[];
+}
+
+export interface SolLargestAccount {
+  address: string;
+  lamports: number;
+}
+
+export interface SolBlockCommitment {
+  commitment: number[] | null;
+  totalStake: number;
+}
+
+export interface SolLatestBlockhash {
+  blockhash: string;
+  lastValidBlockHeight: number;
+}
+
+export interface SolSimulateTransactionResult {
+  // biome-ignore lint/suspicious/noExplicitAny: error format varies
+  err: any;
+  logs: string[] | null;
+  accounts?: (SolAccountInfo | null)[] | null;
+  unitsConsumed?: number;
+  returnData?: SolReturnData | null;
+  innerInstructions?: SolInnerInstruction[] | null;
+}
+
+// ─── Config Types for Method Parameters ───
+
+export interface SolGetAccountInfoConfig {
+  commitment?: Commitment;
+  encoding?: Encoding;
+  dataSlice?: DataSlice;
+  minContextSlot?: number;
+}
+
+export interface SolGetBlockConfig {
+  commitment?: Commitment;
+  encoding?: "json" | "jsonParsed" | "base58" | "base64";
+  transactionDetails?: TransactionDetail;
+  maxSupportedTransactionVersion?: number;
+  rewards?: boolean;
+}
+
+export interface SolGetSignaturesConfig {
+  limit?: number;
+  before?: string;
+  until?: string;
+  commitment?: Commitment;
+  minContextSlot?: number;
+}
+
+export interface SolGetTransactionConfig {
+  commitment?: Commitment;
+  encoding?: "json" | "jsonParsed" | "base58" | "base64";
+  maxSupportedTransactionVersion?: number;
+}
+
+export interface SolSendTransactionConfig {
+  encoding?: "base58" | "base64";
+  skipPreflight?: boolean;
+  preflightCommitment?: Commitment;
+  maxRetries?: number;
+  minContextSlot?: number;
+}
+
+export interface SolSimulateTransactionConfig {
+  commitment?: Commitment;
+  encoding?: "base58" | "base64";
+  sigVerify?: boolean;
+  replaceRecentBlockhash?: boolean;
+  minContextSlot?: number;
+  accounts?: {
+    addresses: string[];
+    encoding?: Encoding;
+  };
+  innerInstructions?: boolean;
+}
+
+export interface SolGetBlockProductionConfig {
+  commitment?: Commitment;
+  identity?: string;
+  range?: {
+    firstSlot: number;
+    lastSlot?: number;
+  };
+}
+
+export interface SolGetLeaderScheduleConfig {
+  commitment?: Commitment;
+  identity?: string;
+}
+
+export interface SolGetSupplyConfig {
+  commitment?: Commitment;
+  excludeNonCirculatingAccountsList?: boolean;
+}
+
+export interface SolGetVoteAccountsConfig {
+  commitment?: Commitment;
+  votePubkey?: string;
+  keepUnstakedDelinquents?: boolean;
+  delinquentSlotDistance?: number;
+}
+
+export interface SolGetProgramAccountsConfig {
+  commitment?: Commitment;
+  encoding?: Encoding;
+  dataSlice?: DataSlice;
+  filters?: SolProgramAccountFilter[];
+  withContext?: boolean;
+  minContextSlot?: number;
+}
+
+export type SolProgramAccountFilter =
+  | { memcmp: { offset: number; bytes: string; encoding?: "base58" | "base64" } }
+  | { dataSize: number };
+
+export interface SolGetInflationRewardConfig {
+  commitment?: Commitment;
+  epoch?: number;
+  minContextSlot?: number;
+}
+
+export interface SolGetLargestAccountsConfig {
+  commitment?: Commitment;
+  filter?: "circulating" | "nonCirculating";
+}
+
+export interface SolGetSignatureStatusesConfig {
+  searchTransactionHistory?: boolean;
+}
+
+export interface SolTokenAccountFilter {
+  mint?: string;
+  programId?: string;
+}
+
+export interface SolGetTokenAccountsConfig {
+  commitment?: Commitment;
+  encoding?: Encoding;
+  dataSlice?: DataSlice;
+  minContextSlot?: number;
+}
+
+// ─── Subscription Notification Types ───
+
+export interface SolAccountNotification {
+  lamports: number;
+  owner: string;
+  // biome-ignore lint/suspicious/noExplicitAny: account data varies by encoding
+  data: string | [string, string] | { program: string; parsed: any; space: number };
+  executable: boolean;
+  rentEpoch: number;
+  space?: number;
+}
+
+export interface SolProgramNotification {
+  pubkey: string;
+  account: SolAccountNotification;
+}
+
+export interface SolLogsNotification {
+  signature: string;
+  // biome-ignore lint/suspicious/noExplicitAny: error format varies
+  err: any;
+  logs: string[];
+}
+
+export interface SolSignatureNotification {
+  // biome-ignore lint/suspicious/noExplicitAny: error format varies
+  err: any;
+}
+
+export interface SolSlotNotification {
+  parent: number;
+  root: number;
+  slot: number;
+}
+
+export interface SolSlotsUpdatesNotification {
+  parent?: number;
+  slot: number;
+  timestamp: number;
+  type:
+    | "firstShredReceived"
+    | "completed"
+    | "createdBank"
+    | "frozen"
+    | "dead"
+    | "optimisticConfirmation"
+    | "root";
+}
+
+/** Root subscription returns a slot number directly */
+export type SolRootNotification = number;
+
+export interface SolBlockNotification {
+  slot: number;
+  // biome-ignore lint/suspicious/noExplicitAny: block format varies by config
+  block: any | null;
+  // biome-ignore lint/suspicious/noExplicitAny: error format varies
+  err: any;
+}
+
+export interface SolVoteNotification {
+  votePubkey: string;
+  hash: string;
+  slots: number[];
+  timestamp: number | null;
+  signature: string;
+}
+
+// ─── Subscription Config Types ───
+
+export interface SolAccountSubscribeConfig {
+  commitment?: Commitment;
+  encoding?: Encoding;
+}
+
+export interface SolProgramSubscribeConfig {
+  commitment?: Commitment;
+  encoding?: Encoding;
+  filters?: SolProgramAccountFilter[];
+}
+
+export interface SolLogsSubscribeConfig {
+  commitment?: Commitment;
+}
+
+export interface SolSignatureSubscribeConfig {
+  commitment?: Commitment;
+  enableReceivedNotification?: boolean;
+}
+
+export interface SolBlockSubscribeConfig {
+  commitment?: Commitment;
+  encoding?: "json" | "jsonParsed" | "base58" | "base64";
+  transactionDetails?: TransactionDetail;
+  maxSupportedTransactionVersion?: number;
+  showRewards?: boolean;
+}

--- a/tests/helpers/env.ts
+++ b/tests/helpers/env.ts
@@ -18,6 +18,7 @@ const ALCHEMY_NETWORKS: Record<string, string> = {
   "avax-mainnet": "avax-mainnet",
   "eth-sepolia": "eth-sepolia",
   "bitcoin-mainnet": "bitcoin-mainnet",
+  "solana-devnet": "solana-devnet",
 };
 
 export function getTestUrls(network: string, baseUrls: string[]): string[] {

--- a/tests/http/factory/ClientFactory.test.ts
+++ b/tests/http/factory/ClientFactory.test.ts
@@ -9,6 +9,12 @@ import { BaseClient } from "../../../src/networks/8453/BaseClient.js";
 import { ArbitrumClient } from "../../../src/networks/42161/ArbitrumClient.js";
 import { AztecClient } from "../../../src/networks/677868/AztecClient.js";
 import { SepoliaClient } from "../../../src/networks/11155111/SepoliaClient.js";
+import { SolanaClient } from "../../../src/networks/solana/SolanaClient.js";
+import {
+  SOLANA_MAINNET,
+  SOLANA_DEVNET,
+  SOLANA_TESTNET,
+} from "../../../src/networks/solana/SolanaTypes.js";
 import type { StrategyConfig } from "../../../src/strategies/requestStrategy.js";
 
 const TEST_URLS = ["https://rpc.example.com"];
@@ -91,6 +97,27 @@ describe("ClientFactory - createClient", () => {
     assert.ok(client instanceof SepoliaClient, "Should create SepoliaClient instance");
     assert.strictEqual(client.getStrategyName(), "fallback", "Should use fallback strategy");
   });
+
+  it("should create SolanaClient for SOLANA_MAINNET", () => {
+    const client = ClientFactory.createClient(SOLANA_MAINNET, TEST_CONFIG);
+
+    assert.ok(client instanceof SolanaClient, "Should create SolanaClient instance");
+    assert.strictEqual(client.getStrategyName(), "fallback", "Should use fallback strategy");
+  });
+
+  it("should create SolanaClient for SOLANA_DEVNET", () => {
+    const client = ClientFactory.createClient(SOLANA_DEVNET, TEST_CONFIG);
+
+    assert.ok(client instanceof SolanaClient, "Should create SolanaClient instance");
+    assert.strictEqual(client.getStrategyName(), "fallback", "Should use fallback strategy");
+  });
+
+  it("should create SolanaClient for SOLANA_TESTNET", () => {
+    const client = ClientFactory.createClient(SOLANA_TESTNET, TEST_CONFIG);
+
+    assert.ok(client instanceof SolanaClient, "Should create SolanaClient instance");
+    assert.strictEqual(client.getStrategyName(), "fallback", "Should use fallback strategy");
+  });
 });
 
 describe("ClientFactory - createTypedClient", () => {
@@ -147,6 +174,13 @@ describe("ClientFactory - createTypedClient", () => {
     const client = ClientFactory.createTypedClient(11155111, TEST_CONFIG);
 
     assert.ok(client instanceof SepoliaClient, "Should create SepoliaClient instance");
+    assert.strictEqual(client.getStrategyName(), "fallback", "Should use fallback strategy");
+  });
+
+  it("should create typed SolanaClient for SOLANA_DEVNET", () => {
+    const client = ClientFactory.createTypedClient(SOLANA_DEVNET, TEST_CONFIG);
+
+    assert.ok(client instanceof SolanaClient, "Should create SolanaClient instance");
     assert.strictEqual(client.getStrategyName(), "fallback", "Should use fallback strategy");
   });
 });

--- a/tests/http/networks/HardhatNetworkClient.test.ts
+++ b/tests/http/networks/HardhatNetworkClient.test.ts
@@ -747,10 +747,7 @@ describe("HardhatNetworkClient - Transaction Methods [strong]", () => {
     );
 
     // Hardhat may or may not support eth_getProof
-    assert.ok(
-      result.success || !result.success,
-      "Should return a result (success or failure)",
-    );
+    assert.ok(result.success || !result.success, "Should return a result (success or failure)");
   });
 
   it("should attempt createAccessList [weak]", async () => {
@@ -894,30 +891,21 @@ describe("HardhatNetworkClient - TxPool Methods [weak]", () => {
     const result = await client.txPoolStatus();
 
     // May succeed or fail depending on Hardhat version
-    assert.ok(
-      result.success || !result.success,
-      "Should return a result",
-    );
+    assert.ok(result.success || !result.success, "Should return a result");
   });
 
   it("should get txpool content [weak]", async () => {
     const client = new HardhatClient(config);
     const result = await client.txPoolContent();
 
-    assert.ok(
-      result.success || !result.success,
-      "Should return a result",
-    );
+    assert.ok(result.success || !result.success, "Should return a result");
   });
 
   it("should get txpool inspect [weak]", async () => {
     const client = new HardhatClient(config);
     const result = await client.txPoolInspect();
 
-    assert.ok(
-      result.success || !result.success,
-      "Should return a result",
-    );
+    assert.ok(result.success || !result.success, "Should return a result");
   });
 });
 
@@ -958,20 +946,14 @@ describe("HardhatNetworkClient - Debug Methods", () => {
       10,
     );
 
-    assert.ok(
-      result.success || !result.success,
-      "Should return a result",
-    );
+    assert.ok(result.success || !result.success, "Should return a result");
   });
 
   it("should attempt debugAccountRange [weak]", async () => {
     const client = new HardhatClient(config);
     const result = await client.debugAccountRange("latest", "0x0", 10);
 
-    assert.ok(
-      result.success || !result.success,
-      "Should return a result",
-    );
+    assert.ok(result.success || !result.success, "Should return a result");
   });
 
   it("should attempt debugGetModifiedAccountsByHash [weak]", async () => {
@@ -981,10 +963,7 @@ describe("HardhatNetworkClient - Debug Methods", () => {
 
     const result = await client.debugGetModifiedAccountsByHash(blockResult.data!.hash);
 
-    assert.ok(
-      result.success || !result.success,
-      "Should return a result",
-    );
+    assert.ok(result.success || !result.success, "Should return a result");
   });
 
   it("should attempt debugGetModifiedAccountsByNumber [weak]", async () => {
@@ -994,10 +973,7 @@ describe("HardhatNetworkClient - Debug Methods", () => {
 
     const result = await client.debugGetModifiedAccountsByNumber(blockNumResult.data!);
 
-    assert.ok(
-      result.success || !result.success,
-      "Should return a result",
-    );
+    assert.ok(result.success || !result.success, "Should return a result");
   });
 });
 
@@ -1021,10 +997,7 @@ describe("HardhatNetworkClient - Trace Methods [weak]", () => {
 
   it("should fail traceCall (unsupported) [weak]", async () => {
     const client = new HardhatClient(config);
-    const result = await client.traceCall(
-      { to: "0x0000000000000000000000000000000000000001" },
-      {},
-    );
+    const result = await client.traceCall({ to: "0x0000000000000000000000000000000000000001" }, {});
 
     validateFailureResult(result);
   });

--- a/tests/http/networks/SolanaClient.test.ts
+++ b/tests/http/networks/SolanaClient.test.ts
@@ -1,0 +1,264 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { SolanaClient } from "../../../src/networks/solana/SolanaClient.js";
+import { SOLANA_DEVNET } from "../../../src/networks/solana/SolanaTypes.js";
+import { ClientFactory } from "../../../src/factory/ClientRegistry.js";
+import type { StrategyConfig } from "../../../src/strategies/requestStrategy.js";
+import { getTestUrls } from "../../helpers/env.js";
+
+const SOLANA_DEVNET_URLS = getTestUrls("solana-devnet", ["https://api.devnet.solana.com"]);
+
+const config: StrategyConfig = {
+  type: "fallback",
+  rpcUrls: SOLANA_DEVNET_URLS,
+};
+
+describe("SolanaClient (HTTP) - Basic Methods [strong]", () => {
+  it("should get version", async () => {
+    const client = new SolanaClient(config);
+    const result = await client.getVersion();
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assert.ok(result.data, "Should have data");
+    assert.strictEqual(
+      typeof result.data["solana-core"],
+      "string",
+      "solana-core should be a string",
+    );
+    assert.strictEqual(
+      typeof result.data["feature-set"],
+      "number",
+      "feature-set should be a number",
+    );
+  });
+
+  it("should get slot", async () => {
+    const client = new SolanaClient(config);
+    const result = await client.getSlot();
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assert.strictEqual(typeof result.data, "number", "Slot should be a number");
+    assert.ok((result.data as number) > 0, "Slot should be positive");
+  });
+
+  it("should get block height", async () => {
+    const client = new SolanaClient(config);
+    const result = await client.getBlockHeight();
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assert.strictEqual(typeof result.data, "number", "Block height should be a number");
+    assert.ok((result.data as number) > 0, "Block height should be positive");
+  });
+
+  it("should get latest blockhash", async () => {
+    const client = new SolanaClient(config);
+    const result = await client.getLatestBlockhash();
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assert.ok(result.data, "Should have data");
+    assert.ok(result.data.context, "Should have context");
+    assert.strictEqual(
+      typeof result.data.context.slot,
+      "number",
+      "context.slot should be a number",
+    );
+    assert.ok(result.data.value, "Should have value");
+    assert.strictEqual(
+      typeof result.data.value.blockhash,
+      "string",
+      "blockhash should be a string",
+    );
+    assert.strictEqual(
+      typeof result.data.value.lastValidBlockHeight,
+      "number",
+      "lastValidBlockHeight should be a number",
+    );
+  });
+
+  it("should get balance for a known address", async () => {
+    const client = new SolanaClient(config);
+    // System program address — always exists, zero balance is fine
+    const result = await client.getBalance("11111111111111111111111111111111");
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assert.ok(result.data, "Should have data");
+    assert.strictEqual(
+      typeof result.data.context.slot,
+      "number",
+      "context.slot should be a number",
+    );
+    assert.strictEqual(typeof result.data.value, "number", "balance value should be a number");
+  });
+
+  it("should get genesis hash matching devnet constant", async () => {
+    const client = new SolanaClient(config);
+    const result = await client.getGenesisHash();
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assert.strictEqual(typeof result.data, "string", "Genesis hash should be a string");
+
+    // Verify the first 32 chars match the CAIP-2 reference in our constant
+    const genesisHash = result.data as string;
+    const caipReference = SOLANA_DEVNET.split(":")[1];
+    assert.strictEqual(
+      genesisHash.substring(0, 32),
+      caipReference,
+      "Genesis hash first 32 chars should match CAIP-2 chain ID reference",
+    );
+  });
+
+  it("should get epoch info", async () => {
+    const client = new SolanaClient(config);
+    const result = await client.getEpochInfo();
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assert.ok(result.data, "Should have data");
+    assert.strictEqual(
+      typeof result.data.absoluteSlot,
+      "number",
+      "absoluteSlot should be a number",
+    );
+    assert.strictEqual(typeof result.data.blockHeight, "number", "blockHeight should be a number");
+    assert.strictEqual(typeof result.data.epoch, "number", "epoch should be a number");
+    assert.strictEqual(typeof result.data.slotIndex, "number", "slotIndex should be a number");
+    assert.strictEqual(
+      typeof result.data.slotsInEpoch,
+      "number",
+      "slotsInEpoch should be a number",
+    );
+  });
+
+  it("should get health", async () => {
+    const client = new SolanaClient(config);
+    const result = await client.getHealth();
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assert.strictEqual(result.data, "ok", "Health should be 'ok'");
+  });
+
+  it("should get epoch schedule", async () => {
+    const client = new SolanaClient(config);
+    const result = await client.getEpochSchedule();
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assert.ok(result.data, "Should have data");
+    assert.strictEqual(
+      typeof result.data.slotsPerEpoch,
+      "number",
+      "slotsPerEpoch should be a number",
+    );
+    assert.strictEqual(typeof result.data.warmup, "boolean", "warmup should be a boolean");
+  });
+
+  it("should get cluster nodes", async () => {
+    const client = new SolanaClient(config);
+    const result = await client.getClusterNodes();
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assert.ok(Array.isArray(result.data), "Should return an array");
+    assert.ok((result.data as unknown[]).length > 0, "Should have at least one node");
+    const node = (result.data as { pubkey: string }[])[0];
+    assert.strictEqual(typeof node.pubkey, "string", "Node pubkey should be a string");
+  });
+
+  it("should get recent performance samples", async () => {
+    const client = new SolanaClient(config);
+    const result = await client.getRecentPerformanceSamples(1);
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assert.ok(Array.isArray(result.data), "Should return an array");
+  });
+});
+
+describe("SolanaClient (HTTP) - Block Methods [strong]", () => {
+  it("should get a block by slot", async () => {
+    const client = new SolanaClient(config);
+
+    // First get a recent slot
+    const slotResult = await client.getSlot("finalized");
+    assert.strictEqual(slotResult.success, true);
+    const slot = slotResult.data as number;
+
+    // Get the block (may be null if slot was skipped)
+    const result = await client.getBlock(slot, {
+      maxSupportedTransactionVersion: 0,
+      transactionDetails: "none",
+      rewards: false,
+    });
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    // Block can be null for skipped slots
+    if (result.data !== null) {
+      assert.strictEqual(typeof result.data.blockhash, "string", "blockhash should be a string");
+      assert.strictEqual(typeof result.data.parentSlot, "number", "parentSlot should be a number");
+      assert.strictEqual(
+        typeof result.data.previousBlockhash,
+        "string",
+        "previousBlockhash should be a string",
+      );
+    }
+  });
+
+  it("should get block time", async () => {
+    const client = new SolanaClient(config);
+    const slotResult = await client.getSlot("finalized");
+    assert.strictEqual(slotResult.success, true);
+    const slot = slotResult.data as number;
+
+    const result = await client.getBlockTime(slot);
+    assert.strictEqual(result.success, true, "Should succeed");
+    // Block time can be null
+    if (result.data !== null) {
+      assert.strictEqual(typeof result.data, "number", "blockTime should be a number");
+    }
+  });
+});
+
+describe("SolanaClient (HTTP) - Transaction Methods [strong]", () => {
+  it("should get recent prioritization fees", async () => {
+    const client = new SolanaClient(config);
+    const result = await client.getRecentPrioritizationFees();
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assert.ok(Array.isArray(result.data), "Should return an array");
+    if ((result.data as unknown[]).length > 0) {
+      const fee = (result.data as { slot: number; prioritizationFee: number }[])[0];
+      assert.strictEqual(typeof fee.slot, "number", "slot should be a number");
+      assert.strictEqual(
+        typeof fee.prioritizationFee,
+        "number",
+        "prioritizationFee should be a number",
+      );
+    }
+  });
+
+  it("should validate blockhash", async () => {
+    const client = new SolanaClient(config);
+
+    // Get a recent blockhash first
+    const bhResult = await client.getLatestBlockhash();
+    assert.strictEqual(bhResult.success, true);
+    const blockhash = bhResult.data?.value.blockhash as string;
+
+    const result = await client.isBlockhashValid(blockhash);
+    assert.strictEqual(result.success, true, "Should succeed");
+    assert.ok(result.data, "Should have data");
+    assert.strictEqual(typeof result.data.value, "boolean", "value should be a boolean");
+  });
+});
+
+describe("SolanaClient (HTTP) - Factory Integration [strong]", () => {
+  it("should create SolanaClient via ClientFactory", () => {
+    const client = ClientFactory.createClient(SOLANA_DEVNET, config);
+
+    assert.ok(client instanceof SolanaClient, "Should create SolanaClient instance");
+    assert.strictEqual(client.getStrategyName(), "fallback", "Should use fallback strategy");
+  });
+
+  it("should create typed SolanaClient via ClientFactory", () => {
+    const client = ClientFactory.createTypedClient(SOLANA_DEVNET, config);
+
+    assert.ok(client instanceof SolanaClient, "Should create SolanaClient instance");
+    assert.strictEqual(client.getStrategyName(), "fallback", "Should use fallback strategy");
+  });
+});

--- a/tests/ws/networks/solana/SolanaClient.test.ts
+++ b/tests/ws/networks/solana/SolanaClient.test.ts
@@ -1,0 +1,121 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { SolanaClient } from "../../../../src/networks/solana/SolanaClient.js";
+import type { SolSlotNotification } from "../../../../src/networks/solana/SolanaTypes.js";
+import type { StrategyConfig } from "../../../../src/strategies/requestStrategy.js";
+
+const SOLANA_DEVNET_WS_URL = "wss://api.devnet.solana.com";
+const SOLANA_DEVNET_HTTP_URL = "https://api.devnet.solana.com";
+
+const config: StrategyConfig = {
+  type: "fallback",
+  rpcUrls: [SOLANA_DEVNET_HTTP_URL, SOLANA_DEVNET_WS_URL],
+};
+
+describe("SolanaClient (WebSocket) - Slot Subscription [strong]", () => {
+  it("should receive slot notifications via slotSubscribe", async () => {
+    const client = new SolanaClient(config);
+
+    try {
+      const notifications: SolSlotNotification[] = [];
+
+      const { subscriptionId, unsubscribe } = await client.slotSubscribe((data) => {
+        notifications.push(data);
+      });
+
+      assert.strictEqual(typeof subscriptionId, "number", "subscriptionId should be a number");
+      assert.ok(subscriptionId >= 0, "subscriptionId should be non-negative");
+
+      // Wait for at least one notification (slots happen every ~400ms)
+      await new Promise<void>((resolve) => {
+        const check = setInterval(() => {
+          if (notifications.length > 0) {
+            clearInterval(check);
+            resolve();
+          }
+        }, 200);
+        // Timeout after 10 seconds
+        setTimeout(() => {
+          clearInterval(check);
+          resolve();
+        }, 10_000);
+      });
+
+      assert.ok(notifications.length > 0, "Should receive at least one slot notification");
+
+      const notification = notifications[0];
+      assert.strictEqual(typeof notification.slot, "number", "slot should be a number");
+      assert.strictEqual(typeof notification.parent, "number", "parent should be a number");
+      assert.strictEqual(typeof notification.root, "number", "root should be a number");
+
+      const result = await unsubscribe();
+      assert.strictEqual(result, true, "Unsubscribe should return true");
+    } finally {
+      await client.close();
+    }
+  });
+});
+
+describe("SolanaClient (WebSocket) - Root Subscription [strong]", () => {
+  it("should receive root notifications via rootSubscribe", async () => {
+    const client = new SolanaClient(config);
+
+    try {
+      const roots: number[] = [];
+
+      const { subscriptionId, unsubscribe } = await client.rootSubscribe((data) => {
+        roots.push(data);
+      });
+
+      assert.strictEqual(typeof subscriptionId, "number", "subscriptionId should be a number");
+
+      // Wait for at least one notification
+      await new Promise<void>((resolve) => {
+        const check = setInterval(() => {
+          if (roots.length > 0) {
+            clearInterval(check);
+            resolve();
+          }
+        }, 200);
+        setTimeout(() => {
+          clearInterval(check);
+          resolve();
+        }, 10_000);
+      });
+
+      assert.ok(roots.length > 0, "Should receive at least one root notification");
+      assert.strictEqual(typeof roots[0], "number", "Root should be a number");
+
+      const result = await unsubscribe();
+      assert.strictEqual(result, true, "Unsubscribe should return true");
+    } finally {
+      await client.close();
+    }
+  });
+});
+
+describe("SolanaClient (WebSocket) - Error Handling [strong]", () => {
+  it("should throw when subscribing without a WebSocket URL", async () => {
+    const httpOnlyConfig: StrategyConfig = {
+      type: "fallback",
+      rpcUrls: [SOLANA_DEVNET_HTTP_URL],
+    };
+    const client = new SolanaClient(httpOnlyConfig);
+
+    await assert.rejects(
+      () => client.slotSubscribe(() => {}),
+      /Solana subscriptions require at least one ws:\/\/ or wss:\/\/ URL/,
+      "Should throw when no WebSocket URL is configured",
+    );
+  });
+
+  it("should close subscription WebSocket on client close", async () => {
+    const client = new SolanaClient(config);
+
+    const { subscriptionId } = await client.slotSubscribe(() => {});
+    assert.strictEqual(typeof subscriptionId, "number", "Should subscribe successfully");
+
+    // close() should not throw
+    await client.close();
+  });
+});


### PR DESCRIPTION
# Description

Adds full Solana JSON-RPC support to `@openscan/network-connectors`, including HTTP methods, WebSocket subscriptions, and CAIP-2 chain ID registration for mainnet-beta, devnet, and testnet.

# Changes

## WebSocket Subscription Infrastructure
- Added `subscribe()` method to `WebSocketRpcClient` for server-pushed notifications (pubsub pattern)
- Subscription handlers receive notification payloads and get cleaned up on connection loss
- Returns an `unsubscribe()` function for clean teardown
- Added `JsonRpcNotification` type for subscription message parsing

## Solana Client (`SolanaClient`)
- **54 HTTP RPC methods**: account queries, block/slot info, token operations, staking, cluster info, fee estimation, transaction submission, and more
- **9 WebSocket subscriptions**: `accountSubscribe`, `programSubscribe`, `logsSubscribe`, `signatureSubscribe`, `slotSubscribe`, `slotsUpdatesSubscribe`, `rootSubscribe`, `blockSubscribe`, `voteSubscribe`
- Subscription WebSocket is lazily created from the first `wss://` URL in `rpcUrls`, independent of the strategy layer
- Comprehensive type definitions (~600 lines) covering all Solana RPC response structures

## Factory & Exports
- Registered `SolanaClient` in `ClientFactory` with CAIP-2 chain IDs (`solana:*`)
- Added `SupportedSolanaChainId` type and updated `SupportedNetwork` union
- Full type-safe `createClient()` / `createTypedClient()` overloads
- All public types and constants exported from `index.ts`

# Tests
- HTTP tests for Solana client (method invocations, factory integration)
- WebSocket tests for Solana client
- Factory tests for all three Solana chain IDs (`SOLANA_MAINNET`, `SOLANA_DEVNET`, `SOLANA_TESTNET`)

# Supported Networks

| Network | CAIP-2 Chain ID | Constant |
|---------|----------------|----------|
| Mainnet Beta | `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` | `SOLANA_MAINNET` |
| Devnet | `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` | `SOLANA_DEVNET` |
| Testnet | `solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z` | `SOLANA_TESTNET` |
