### PR TITLE
feat: Add Zcash support (Zebra RPC) + per-endpoint HTTP headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,19 @@
 ALCHEMY_API_KEY=<alchemy_api_key>
+
+# Optional. Tatum serves the only free no-key Zcash JSON-RPC endpoints, but caps
+# anonymous traffic at 5 requests/minute — shared across all its hosts, so listing
+# several buys redundancy, not throughput. A key raises this to 200 req/s and lets
+# the full live Zcash test suite run.
+# Sent as the `x-api-key` header; a key placed in the URL path is silently ignored.
+#
+# Note: the key raises the rate limit ONLY. Tatum's gateway whitelist is fixed, not
+# tier-based — every z_* and getaddress* method, plus getinfo, getpeerinfo,
+# getmininginfo, getblocksubsidy and getstandardfee, returns -32601 with or without
+# a key. Use ZCASH_RPC_URL below to exercise those.
+TATUM_API_KEY=<tatum_api_key>
+
+# Optional. A self-hosted zebrad or other Zcash provider, used ahead of the public
+# gateways. The only way to exercise the shielded (z_*), address-index and
+# node-admin RPCs, which no hosted free endpoint exposes.
+# For a local node with cookie auth disabled: http://127.0.0.1:8232
+ZCASH_RPC_URL=<zcash_rpc_url>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,9 @@ This file provides structured context for AI assistants to understand the @opens
 │   │   ├── 43114/               # Avalanche C-Chain
 │   │   ├── 677868/              # Aztec
 │   │   ├── 11155111/            # Sepolia Testnet
-│   │   └── bitcoin/             # Bitcoin (CAIP-2: bip122:*)
+│   │   ├── bitcoin/             # Bitcoin (CAIP-2: bip122:*)
+│   │   ├── zcash/               # Zcash (CAIP-2: bip122:*, Zebra RPC)
+│   │   └── solana/              # Solana (CAIP-2: solana:*)
 │   ├── factory/                 # Client instantiation
 │   │   └── ClientRegistry.ts    # Chain ID to client mapping
 │   ├── NetworkClient.ts         # Base network client (concrete)
@@ -88,7 +90,8 @@ Concrete base class providing:
 - `execute<T>(method: string, params: any[]): Promise<StrategyResult<T>>` - Generic RPC method execution
 - `getStrategy(): RequestStrategy` - Get current strategy instance
 - `getStrategyName(): string` - Get strategy name ("fallback", "parallel", or "race")
-- `getRpcUrls(): string[]` - Get configured RPC URLs
+- `getRpcUrls(): string[]` - Get configured RPC URLs (endpoint objects normalized to their URL)
+- `getRpcEndpoints(): (string | RpcEndpoint)[]` - Get configured endpoints verbatim, preserving headers
 - `updateStrategy(type: StrategyConfig["type"]): void` - Dynamically switch strategies (closes old strategy's transports before replacing)
 - `close(): Promise<void>` - Close underlying transports (e.g., WebSocket connections)
 
@@ -119,18 +122,38 @@ interface JsonRpcTransport {
 
 #### createTransport() Factory ([src/JsonRpcTransport.ts](src/JsonRpcTransport.ts))
 
-Auto-detects transport from URL scheme:
+Auto-detects transport from URL scheme, and accepts either a plain URL string or an `RpcEndpoint` carrying per-endpoint headers:
 
 ```typescript
-function createTransport(url: string): JsonRpcTransport {
+interface RpcEndpoint {
+  url: string;
+  headers?: Record<string, string>;  // HTTP only — the WS handshake takes no custom headers
+}
+
+function createTransport(endpoint: string | RpcEndpoint): JsonRpcTransport {
+  const url = typeof endpoint === "string" ? endpoint : endpoint.url;
   if (url.startsWith("ws://") || url.startsWith("wss://")) {
     return new WebSocketRpcClient(url);
   }
-  return new RpcClient(url);  // HTTP
+  return new RpcClient(url, typeof endpoint === "string" ? undefined : endpoint.headers);  // HTTP
 }
 ```
 
 Used by `StrategyFactory.create()` to build transports — strategies accept `JsonRpcTransport[]` and can mix HTTP and WebSocket endpoints.
+
+**Authenticated endpoints**: providers that require an API key header (e.g. Tatum's `x-api-key`) are configured as objects. Headers are scoped per endpoint, so a credential is never sent to the other providers in the same `rpcUrls` list:
+
+```typescript
+const config = {
+  type: "fallback" as const,
+  rpcUrls: [
+    { url: "https://zcash-mainnet.gateway.tatum.io", headers: { "x-api-key": process.env.TATUM_API_KEY! } },
+    "https://zcash-mainnet-zebrad.gateway.tatum.io",  // plain strings still work
+  ],
+};
+```
+
+`NetworkClient.getRpcUrls()` still returns `string[]`, normalizing endpoint objects to their URL so headers are never exposed. Use `getRpcEndpoints()` to read back the configured entries verbatim.
 
 #### WebSocketRpcClient ([src/WebSocketRpcClient.ts](src/WebSocketRpcClient.ts))
 
@@ -211,9 +234,14 @@ interface RPCProviderResponse {
   hash?: string;  // Response hash for inconsistency detection
 }
 
+interface RpcEndpoint {
+  url: string;
+  headers?: Record<string, string>;  // HTTP transports only
+}
+
 interface StrategyConfig {
   type: "fallback" | "parallel" | "race";
-  rpcUrls: string[];
+  rpcUrls: (string | RpcEndpoint)[];  // plain strings remain valid
 }
 ```
 
@@ -426,6 +454,13 @@ static create(config: StrategyConfig): RequestStrategy {
 | Bitcoin Testnet3 | `bip122:000000000933ea01ad0ee984209779ba` | `BitcoinClient` | Bitcoin testnet3 network |
 | Bitcoin Testnet4 | `bip122:00000000da84f2bafbbc53dee25a72ae` | `BitcoinClient` | Bitcoin testnet4 (BIP94) |
 | Bitcoin Signet | `bip122:00000008819873e925422c1ff0f99f7c` | `BitcoinClient` | Bitcoin signet (BIP325) |
+| Zcash Mainnet | `bip122:00040fe8ec8471911baa1db1266ea15d` | `ZcashClient` | Zebra (`zebrad`) RPC (~40 methods), shielded pools |
+| Zcash Testnet | `bip122:05a60a92d99d85997cce3b87616c089f` | `ZcashClient` | Zcash testnet |
+| Solana Mainnet Beta | `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` | `SolanaClient` | Full Solana JSON-RPC + WebSocket subscriptions |
+| Solana Devnet | `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` | `SolanaClient` | Solana devnet cluster |
+| Solana Testnet | `solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z` | `SolanaClient` | Solana testnet cluster |
+
+**Note on `bip122:`**: Bitcoin and Zcash share the BIP122 CAIP-2 namespace, since Zcash is a Bitcoin fork. `ClientFactory` therefore routes CAIP-2 identifiers by **registry membership** (`network in ZCASH_REGISTRY`), never by prefix matching. Any future Bitcoin fork must follow the same pattern.
 
 ### Network-Specific Method Categories
 
@@ -504,6 +539,37 @@ Bitcoin Core v28+ specific features supported:
 - `getPrioritisedTransactions()` - New mempool inspection
 - `submitPackage()` with `maxfeerate` and `maxburnamount` params
 - Array-based `warnings` field in info responses
+
+**Zcash** ([src/networks/zcash/ZcashClient.ts](src/networks/zcash/ZcashClient.ts)):
+
+Zcash models the **Zebra (`zebrad`)** RPC surface, not the legacy `zcashd` one. `zcashd` reached its automatic end-of-support halt on 2026-07-18 at block 3417100 and no longer runs, so its ~130-method surface targets software that is gone. Wallet RPCs (`z_sendmany`, `z_getbalance`, …) belong to the separate Zallet daemon and are out of scope.
+
+Method categories (~40 methods):
+
+- **Chain & Blocks** (8): `getBlockchainInfo()`, `getBlockCount()`, `getBestBlockHash()`, `getBestBlockHeightAndHash()`, `getBlockHash()`, `getBlock()`, `getBlockHeader()`, `getDifficulty()`
+- **Transactions** (3): `getRawTransaction()`, `sendRawTransaction()`, `getTxOut()`
+- **Mempool** (2): `getMempoolInfo()`, `getRawMempool()`
+- **Address Index** (3): `getAddressBalance()`, `getAddressTxIds()`, `getAddressUtxos()`
+- **Shielded** (4): `zGetTreestate()`, `zGetSubtreesByIndex()`, `zValidateAddress()`, `zListUnifiedReceivers()`
+- **Mining** (9): `getBlockTemplate()`, `submitBlock()`, `getMiningInfo()`, `getNetworkSolPs()`, `getNetworkHashPs()`, `getBlockSubsidy()`, `getStandardFee()`, `generate()`, `generateToAddress()`
+- **Node & Network** (8): `getInfo()`, `getDeprecationInfo()`, `getNetworkInfo()`, `getPeerInfo()`, `ping()`, `addNode()`, `stop()`, `validateAddress()`
+- **Chain Manipulation** (2): `invalidateBlock()`, `reconsiderBlock()`
+
+Zcash-specific conventions that differ from Bitcoin — easy to get wrong:
+
+- **`hash_or_height` is a string.** `getBlock()`, `getBlockHeader()` and `zGetTreestate()` take a block hash *or a height as a decimal string*: `getBlock("3444000", 1)`, not `getBlock(3444000, 1)`.
+- **`getRawTransaction` verbosity is numeric** (`0` = hex, `1` = object), not a boolean as in Bitcoin. It takes an optional third `blockHash`.
+- **Address-index methods take an object bag**, not positional args: `getAddressBalance({ addresses: ["t1..."] })`.
+- The registered method name is `getstandardfee` (one word).
+- **HTTP only.** Zebra's RPC server is built `.http_only()`, so Zcash has no WebSocket transport, no subscriptions, and no `tests/ws/` directory.
+- Response shapes carry Zcash-only fields: `nonce` is a 32-byte hex string (not a number), `solution` holds the Equihash solution, blocks carry `finalsaplingroot`/`finalorchardroot` and `trees` (note commitment tree sizes), and `getblockchaininfo` reports per-pool `valuePools` (`transparent`, `sprout`, `sapling`, `orchard`, `lockbox`, `ironwood`).
+
+**Solana** ([src/networks/solana/SolanaClient.ts](src/networks/solana/SolanaClient.ts)):
+
+- Uses CAIP-2 `solana:*` chain IDs (first 32 chars of the genesis hash)
+- Full JSON-RPC surface plus **WebSocket subscriptions** (`accountSubscribe`, `slotSubscribe`, `logsSubscribe`, …)
+- The subscription WebSocket is created lazily from the first `ws://`/`wss://` URL in `rpcUrls` and is independent of the strategy — `updateStrategy()` does not affect it
+- Overrides `close()` to tear down the subscription socket in addition to the strategy transports
 
 ## Common Code Patterns
 
@@ -585,8 +651,18 @@ type SupportedChainId = 1 | 10 | 56 | 97 | 137 | 8453 | 42161 | 43114 | 677868 |
 // Bitcoin chain IDs (CAIP-2/BIP122 format)
 type SupportedBitcoinChainId = BitcoinChainId;  // "bip122:000000000019d6689c085ae165831e93" | ...
 
+// Zcash chain IDs (CAIP-2/BIP122 format - same namespace as Bitcoin)
+type SupportedZcashChainId = ZcashChainId;      // "bip122:00040fe8ec8471911baa1db1266ea15d" | ...
+
+// Solana chain IDs (CAIP-2/solana format)
+type SupportedSolanaChainId = SolanaChainId;    // "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp" | ...
+
 // All supported networks
-type SupportedNetwork = SupportedChainId | SupportedBitcoinChainId;
+type SupportedNetwork =
+  | SupportedChainId
+  | SupportedBitcoinChainId
+  | SupportedZcashChainId
+  | SupportedSolanaChainId;
 
 // Maps EVM chain ID to client type
 type ChainIdToClient<T extends SupportedChainId> =
@@ -603,6 +679,8 @@ type ChainIdToClient<T extends SupportedChainId> =
 
 // Maps any network identifier to client type
 type NetworkToClient<T extends SupportedNetwork> =
+  T extends SupportedSolanaChainId ? SolanaClient :
+  T extends SupportedZcashChainId ? ZcashClient :
   T extends SupportedBitcoinChainId ? BitcoinClient :
   T extends SupportedChainId ? ChainIdToClient<T> :
   NetworkClient;
@@ -623,6 +701,8 @@ static createClient(chainId: 42161, config: StrategyConfig): ArbitrumClient;
 static createClient(chainId: 43114, config: StrategyConfig): AvalancheClient;
 static createClient(chainId: 677868, config: StrategyConfig): AztecClient;
 static createClient(chainId: SupportedBitcoinChainId, config: StrategyConfig): BitcoinClient;
+static createClient(chainId: SupportedZcashChainId, config: StrategyConfig): ZcashClient;
+static createClient(chainId: SupportedSolanaChainId, config: StrategyConfig): SolanaClient;
 static createClient(network: SupportedNetwork, config: StrategyConfig): NetworkClient;
 
 // Type-safe client with generic inference
@@ -821,16 +901,19 @@ Tests are split by transport to validate both HTTP and WebSocket:
 
 To add a new network:
 
-1. Create directory in [src/networks/](src/networks/) with chain ID
-2. Define network-specific types (if needed)
+1. Create directory in [src/networks/](src/networks/) — named by numeric chain ID for EVM chains, by lowercase name for non-EVM chains (`bitcoin/`, `zcash/`, `solana/`)
+2. Define network-specific types. For non-EVM chains, declare the CAIP-2 chain ID constants and the `<Name>ChainId` union **in the types file** — the registry imports them from there
 3. Create client class extending `NetworkClient`
 4. Implement network-specific RPC methods
-5. Update `SupportedChainId` type in [src/factory/ClientRegistry.ts](src/factory/ClientRegistry.ts)
-6. Update `ChainIdToClient` type mapping
-7. Add case to factory `createClient()` and `createTypedClient()` methods
-8. Export from [src/index.ts](src/index.ts)
-9. Add HTTP tests in [tests/http/networks/](tests/http/networks/)
-10. Add WebSocket tests in [tests/ws/networks/<CHAIN_ID>/](tests/ws/networks/)
+5. Wire up [src/factory/ClientRegistry.ts](src/factory/ClientRegistry.ts) — the steps differ by chain kind:
+   - **EVM**: add the ID to `SupportedChainId`, update `ChainIdToClient`, add a `CHAIN_REGISTRY` entry, add a `createClient()` overload
+   - **CAIP-2** (Bitcoin, Zcash, Solana): add a `Supported<Name>ChainId` alias, extend `SupportedNetwork`, add a branch to **`NetworkToClient`** (*not* `ChainIdToClient`, which is EVM-only), add a `<NAME>_REGISTRY`, add an `is<Name>Network()` guard, then add the `createClient()` overload and a dispatch branch
+   - `createTypedClient()` needs no change — it delegates and casts through `NetworkToClient<T>`
+6. **Write the type guard as a registry-membership test** (`network in <NAME>_REGISTRY`), never a namespace prefix check. Bitcoin and Zcash both live under `bip122:`, so prefix matching silently misroutes one into the other's registry
+7. Export from [src/index.ts](src/index.ts): banner comment, value export of the client, value export of the chain ID constants, then one `export type {}` block
+8. Add HTTP tests in [tests/http/networks/](tests/http/networks/) and factory cases in [tests/http/factory/ClientFactory.test.ts](tests/http/factory/ClientFactory.test.ts)
+9. Add WebSocket tests in [tests/ws/networks/<CHAIN_ID>/](tests/ws/networks/) — **only if the network actually has a WebSocket RPC**. Bitcoin and Zcash do not (Zebra's RPC server is HTTP-only), so they ship HTTP tests only
+10. Update the network tables in both [README.md](README.md) and this file
 
 ## Adding New RPC Methods
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ TypeScript library providing unified, type-safe RPC client interfaces for multip
 
 ## Features
 
-- **Multi-Network Support**: Unified API for 10+ blockchain networks including EVM chains (Ethereum, Optimism, Arbitrum, Polygon, BNB, Base, Avalanche, Aztec) and Bitcoin
+- **Multi-Network Support**: Unified API for 10+ blockchain networks including EVM chains (Ethereum, Optimism, Arbitrum, Polygon, BNB, Base, Avalanche, Aztec), Bitcoin, Zcash and Solana
 - **Bitcoin Support**: Full Bitcoin Core v28+ RPC support with ~115 methods using CAIP-2/BIP122 chain identifiers
+- **Zcash Support**: Full Zebra (`zebrad`) RPC support with ~40 methods, including the shielded pool and address-index RPCs
 - **Strategy Pattern**: Pluggable request execution strategies (Fallback for reliability, Parallel for consistency detection, Race for minimum latency)
 - **Type Safety**: Strong TypeScript typing with network-specific type definitions
 - **Dual Transport**: HTTP and WebSocket support with automatic transport detection from URL scheme
@@ -85,6 +86,58 @@ import {
 | Mining | ~9 | `getMiningInfo`, `getNetworkHashPs`, `getBlockTemplate`, `submitBlock`, `generateToAddress`, etc. |
 | Wallet | ~35 | `getWalletInfo`, `getBalances`, `listWallets`, `sendToAddress`, `listUnspent`, `importDescriptors`, etc. |
 | Control | ~6 | `getMemoryInfo`, `getRpcInfo`, `help`, `uptime`, `logging`, `stop` |
+
+### Zcash Networks
+
+Zcash is a Bitcoin fork, so it shares the `bip122:` CAIP-2 namespace with Bitcoin. Chain IDs are still unique — the reference is the first 32 hex characters of each chain's genesis block hash — and the factory routes on registry membership rather than the namespace prefix.
+
+| Network | Chain ID (CAIP-2) | Client Class | Special Features |
+|---------|-------------------|--------------|------------------|
+| Zcash Mainnet | `bip122:00040fe8ec8471911baa1db1266ea15d` | `ZcashClient` | Full Zebra RPC (~40 methods) incl. shielded pools |
+| Zcash Testnet | `bip122:05a60a92d99d85997cce3b87616c089f` | `ZcashClient` | Zcash testnet |
+
+> **Node implementation**: `zcashd` reached its automatic end-of-support halt on 2026-07-18 and no longer runs. `ZcashClient` therefore models the RPC surface of [Zebra](https://zebra.zfnd.org/) (`zebrad`), the current Zcash node. Wallet RPCs (`z_sendmany`, `z_getbalance`, …) live in the separate Zallet daemon and are not covered here.
+>
+> **Transport**: Zebra's RPC server is HTTP-only, so Zcash has no WebSocket transport or subscription support.
+
+#### Zcash Chain ID Constants
+
+```typescript
+import { ZCASH_MAINNET, ZCASH_TESTNET } from "@openscan/network-connectors";
+
+// ZCASH_MAINNET = "bip122:00040fe8ec8471911baa1db1266ea15d"
+```
+
+#### Zcash Method Categories (~40 methods)
+
+| Category | Methods | Description |
+|----------|---------|-------------|
+| Chain & Blocks | 8 | `getBlockchainInfo`, `getBlockCount`, `getBestBlockHash`, `getBestBlockHeightAndHash`, `getBlockHash`, `getBlock`, `getBlockHeader`, `getDifficulty` |
+| Transactions | 3 | `getRawTransaction`, `sendRawTransaction`, `getTxOut` |
+| Mempool | 2 | `getMempoolInfo`, `getRawMempool` |
+| Address Index | 3 | `getAddressBalance`, `getAddressTxIds`, `getAddressUtxos` |
+| Shielded | 4 | `zGetTreestate`, `zGetSubtreesByIndex`, `zValidateAddress`, `zListUnifiedReceivers` |
+| Mining | 9 | `getBlockTemplate`, `submitBlock`, `getMiningInfo`, `getNetworkSolPs`, `getBlockSubsidy`, `getStandardFee`, `generate`, `generateToAddress`, `getNetworkHashPs` |
+| Node & Network | 8 | `getInfo`, `getDeprecationInfo`, `getNetworkInfo`, `getPeerInfo`, `ping`, `addNode`, `stop`, `validateAddress` |
+| Chain Manipulation | 2 | `invalidateBlock`, `reconsiderBlock` |
+
+Note some parameter conventions differ from Bitcoin: `getBlock`, `getBlockHeader` and `zGetTreestate` take a block hash **or a height as a decimal string** (`getBlock("3444000", 1)`); `getRawTransaction` takes a numeric verbosity (`0` or `1`) rather than a boolean; and the address-index methods take a single object argument (`getAddressBalance({ addresses: ["t1..."] })`).
+
+## Authenticated RPC Endpoints
+
+Endpoints that require an API key header can be configured as objects instead of plain URL strings. Headers are scoped per endpoint, so a credential is never sent to the other providers in the same list:
+
+```typescript
+const client = ClientFactory.createClient(ZCASH_MAINNET, {
+  type: "fallback",
+  rpcUrls: [
+    { url: "https://zcash-mainnet.gateway.tatum.io", headers: { "x-api-key": process.env.TATUM_API_KEY! } },
+    "https://zcash-mainnet-zebrad.gateway.tatum.io", // plain strings still work
+  ],
+});
+```
+
+Headers apply to HTTP transports only — the WebSocket handshake does not support custom headers.
 
 ## Project Structure
 
@@ -331,12 +384,15 @@ To add support for a new blockchain network:
 1. **Create network directory**:
 
    ```bash
-   mkdir -p src/networks/<CHAIN_ID>
+   mkdir -p src/networks/<CHAIN_ID>   # EVM chains use the numeric chain ID
+   mkdir -p src/networks/<name>       # non-EVM chains use a lowercase name (bitcoin, zcash, solana)
    ```
 
 2. **Define network-specific types** (if needed):
    - Create types file for network-specific data structures
    - Extend base Ethereum types if applicable
+   - For non-EVM chains, declare the CAIP-2 chain ID constants and the `<Name>ChainId`
+     union here — the registry imports them from the types file
 
 3. **Create client class**:
    - Extend `NetworkClient` base class
@@ -344,21 +400,29 @@ To add support for a new blockchain network:
    - Use `this.execute<T>(method, params)` for all RPC calls
    - Add JSDoc comments for all public methods
 
-4. **Update factory**:
-   - Add chain ID to `SupportedChainId` type in [src/factory/ClientRegistry.ts](src/factory/ClientRegistry.ts)
-   - Update `ChainIdToClient` type mapping
-   - Add case to `createClient()` and `createTypedClient()` methods
+4. **Update factory** in [src/factory/ClientRegistry.ts](src/factory/ClientRegistry.ts):
+   - **EVM chains**: add the chain ID to `SupportedChainId`, update the `ChainIdToClient`
+     mapping, add an entry to `CHAIN_REGISTRY`, and add a `createClient()` overload
+   - **CAIP-2 chains** (Bitcoin, Zcash, Solana): add a `Supported<Name>ChainId` alias,
+     extend `SupportedNetwork`, add a branch to **`NetworkToClient`** (not `ChainIdToClient`),
+     add a `<NAME>_REGISTRY`, add an `is<Name>Network()` guard that tests **registry
+     membership** (never a namespace prefix — Bitcoin and Zcash share `bip122:`), then add
+     the `createClient()` overload and a dispatch branch
+   - `createTypedClient()` needs no change; it delegates and casts through `NetworkToClient`
 
 5. **Export from index**:
-   - Add exports to [src/index.ts](src/index.ts)
+   - Add exports to [src/index.ts](src/index.ts): a banner comment, a value export for the
+     client, a value export for the chain ID constants, then one `export type {}` block
 
 6. **Add tests**:
    - Create HTTP test file in `tests/http/networks/`
-   - Create WebSocket test directory and file in `tests/ws/networks/<CHAIN_ID>/`
+   - Create a WebSocket test directory and file in `tests/ws/networks/<CHAIN_ID>/`, **if the
+     network has a WebSocket RPC** — Bitcoin and Zcash do not, so they have HTTP tests only
+   - Add factory cases to `tests/http/factory/ClientFactory.test.ts`
    - Test client instantiation, methods, and type safety
 
 7. **Update documentation**:
-   - Add network to supported networks table in README.md
+   - Add network to supported networks table in README.md and CLAUDE.md
    - Document any special features or methods
 
 ### Adding New RPC Methods

--- a/src/JsonRpcTransport.ts
+++ b/src/JsonRpcTransport.ts
@@ -13,13 +13,34 @@ export interface JsonRpcTransport {
 }
 
 /**
+ * An RPC endpoint with optional per-endpoint HTTP headers.
+ *
+ * Use this instead of a plain URL string when a provider requires authentication
+ * headers (e.g. `{ "x-api-key": "..." }`). Headers are scoped to this endpoint only,
+ * so a credential is never sent to the other URLs configured in the same strategy.
+ *
+ * Headers apply to HTTP transports only — the WebSocket handshake does not
+ * support custom headers.
+ */
+export interface RpcEndpoint {
+  url: string;
+  headers?: Record<string, string>;
+}
+
+/**
  * Creates a transport based on URL scheme.
  * - ws:// or wss:// → WebSocketRpcClient
  * - http:// or https:// → RpcClient (HTTP)
+ *
+ * Accepts either a plain URL string or an {@link RpcEndpoint} carrying headers.
+ * Headers are applied to HTTP transports only — the WebSocket handshake does not
+ * support custom headers, so they are ignored for ws:// and wss:// URLs.
  */
-export function createTransport(url: string): JsonRpcTransport {
+export function createTransport(endpoint: string | RpcEndpoint): JsonRpcTransport {
+  const url = typeof endpoint === "string" ? endpoint : endpoint.url;
+
   if (url.startsWith("ws://") || url.startsWith("wss://")) {
     return new WebSocketRpcClient(url);
   }
-  return new RpcClient(url);
+  return new RpcClient(url, typeof endpoint === "string" ? undefined : endpoint.headers);
 }

--- a/src/NetworkClient.ts
+++ b/src/NetworkClient.ts
@@ -1,5 +1,6 @@
 import type { RequestStrategy, StrategyResult } from "./strategies/strategiesTypes.js";
 import { StrategyFactory, type StrategyConfig } from "./strategies/requestStrategy.js";
+import type { RpcEndpoint } from "./JsonRpcTransport.js";
 
 /**
  * Base network client that uses strategy pattern for RPC requests
@@ -7,7 +8,7 @@ import { StrategyFactory, type StrategyConfig } from "./strategies/requestStrate
  */
 export class NetworkClient {
   protected strategy: RequestStrategy;
-  protected rpcUrls: string[];
+  protected rpcUrls: (string | RpcEndpoint)[];
 
   constructor(config: StrategyConfig) {
     this.strategy = StrategyFactory.create(config);
@@ -41,8 +42,18 @@ export class NetworkClient {
 
   /**
    * Get the RPC URLs
+   *
+   * Endpoints configured as objects are normalized to their URL, so this always
+   * returns plain strings and never exposes configured headers.
    */
   getRpcUrls(): string[] {
+    return this.rpcUrls.map((endpoint) => (typeof endpoint === "string" ? endpoint : endpoint.url));
+  }
+
+  /**
+   * Get the configured endpoints as provided, preserving any per-endpoint headers
+   */
+  getRpcEndpoints(): (string | RpcEndpoint)[] {
     return this.rpcUrls;
   }
 

--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -3,10 +3,16 @@ import type { JsonRpcRequest, JsonRpcResponse } from "./RpcClientTypes.js";
 
 export class RpcClient implements JsonRpcTransport {
   private url: string;
+  private headers: Record<string, string>;
   private requestId: number = 0;
 
-  constructor(url: string) {
+  /**
+   * @param url - The HTTP(S) JSON-RPC endpoint
+   * @param headers - Optional extra headers (e.g. `{ "x-api-key": "..." }`) sent with every request
+   */
+  constructor(url: string, headers?: Record<string, string>) {
     this.url = url;
+    this.headers = headers ?? {};
   }
 
   // biome-ignore lint/suspicious/noExplicitAny: <TODO>
@@ -22,6 +28,7 @@ export class RpcClient implements JsonRpcTransport {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        ...this.headers,
       },
       body: JSON.stringify(request),
     });

--- a/src/factory/ClientRegistry.ts
+++ b/src/factory/ClientRegistry.ts
@@ -18,6 +18,8 @@ import {
   BITCOIN_SIGNET,
   type BitcoinChainId,
 } from "../networks/bitcoin/BitcoinTypes.js";
+import { ZcashClient } from "../networks/zcash/ZcashClient.js";
+import { ZCASH_MAINNET, ZCASH_TESTNET, type ZcashChainId } from "../networks/zcash/ZcashTypes.js";
 import { SolanaClient } from "../networks/solana/SolanaClient.js";
 import {
   SOLANA_MAINNET,
@@ -48,14 +50,27 @@ export type SupportedChainId =
 export type SupportedBitcoinChainId = BitcoinChainId;
 
 /**
+ * Supported Zcash chain IDs (CAIP-2 format with BIP122 namespace)
+ *
+ * Note Zcash shares the `bip122:` namespace with Bitcoin, since it is a Bitcoin
+ * fork. Routing therefore discriminates on registry membership, not on the
+ * namespace prefix — see {@link isZcashNetwork} and {@link isBitcoinNetwork}.
+ */
+export type SupportedZcashChainId = ZcashChainId;
+
+/**
  * Supported Solana chain IDs (CAIP-2 format with solana namespace)
  */
 export type SupportedSolanaChainId = SolanaChainId;
 
 /**
- * All supported network identifiers (EVM chain IDs + Bitcoin + Solana CAIP-2 chain IDs)
+ * All supported network identifiers (EVM chain IDs + Bitcoin, Zcash and Solana CAIP-2 chain IDs)
  */
-export type SupportedNetwork = SupportedChainId | SupportedBitcoinChainId | SupportedSolanaChainId;
+export type SupportedNetwork =
+  | SupportedChainId
+  | SupportedBitcoinChainId
+  | SupportedZcashChainId
+  | SupportedSolanaChainId;
 
 /**
  * Constructor type for network clients
@@ -90,11 +105,13 @@ export type ChainIdToClient<T extends SupportedChainId> = T extends 1 | 11155111
  */
 export type NetworkToClient<T extends SupportedNetwork> = T extends SupportedSolanaChainId
   ? SolanaClient
-  : T extends SupportedBitcoinChainId
-    ? BitcoinClient
-    : T extends SupportedChainId
-      ? ChainIdToClient<T>
-      : NetworkClient;
+  : T extends SupportedZcashChainId
+    ? ZcashClient
+    : T extends SupportedBitcoinChainId
+      ? BitcoinClient
+      : T extends SupportedChainId
+        ? ChainIdToClient<T>
+        : NetworkClient;
 
 /**
  * Registry mapping EVM chain IDs to their corresponding client constructors
@@ -124,6 +141,14 @@ const BITCOIN_REGISTRY: Record<SupportedBitcoinChainId, typeof BitcoinClient> = 
 };
 
 /**
+ * Registry mapping Zcash CAIP-2 chain IDs to the Zcash client constructor
+ */
+const ZCASH_REGISTRY: Record<SupportedZcashChainId, typeof ZcashClient> = {
+  [ZCASH_MAINNET]: ZcashClient,
+  [ZCASH_TESTNET]: ZcashClient,
+};
+
+/**
  * Registry mapping Solana CAIP-2 chain IDs to the Solana client constructor
  */
 const SOLANA_REGISTRY: Record<SupportedSolanaChainId, typeof SolanaClient> = {
@@ -133,10 +158,23 @@ const SOLANA_REGISTRY: Record<SupportedSolanaChainId, typeof SolanaClient> = {
 };
 
 /**
+ * Check if a network identifier is a Zcash CAIP-2 chain ID
+ *
+ * Matches on registry membership rather than the `bip122:` prefix, which Zcash
+ * shares with Bitcoin.
+ */
+function isZcashNetwork(network: SupportedNetwork): network is SupportedZcashChainId {
+  return typeof network === "string" && network in ZCASH_REGISTRY;
+}
+
+/**
  * Check if a network identifier is a Bitcoin CAIP-2 chain ID
+ *
+ * Matches on registry membership rather than the `bip122:` prefix, which Bitcoin
+ * shares with Zcash (and would share with any other Bitcoin fork added later).
  */
 function isBitcoinNetwork(network: SupportedNetwork): network is SupportedBitcoinChainId {
-  return typeof network === "string" && network.startsWith("bip122:");
+  return typeof network === "string" && network in BITCOIN_REGISTRY;
 }
 
 /**
@@ -196,6 +234,10 @@ export class ClientFactory {
    */
   static createClient(chainId: SupportedBitcoinChainId, config: StrategyConfig): BitcoinClient;
   /**
+   * Create a Zcash client (CAIP-2 chain ID)
+   */
+  static createClient(chainId: SupportedZcashChainId, config: StrategyConfig): ZcashClient;
+  /**
    * Create a Solana client (CAIP-2 chain ID)
    */
   static createClient(chainId: SupportedSolanaChainId, config: StrategyConfig): SolanaClient;
@@ -206,7 +248,7 @@ export class ClientFactory {
   /**
    * Create a network client for the specified network identifier
    *
-   * @param network - The network identifier (EVM chain ID, Bitcoin or Solana CAIP-2 chain ID)
+   * @param network - The network identifier (EVM chain ID, or Bitcoin, Zcash or Solana CAIP-2 chain ID)
    * @param config - Strategy configuration with RPC URLs and strategy type
    * @returns NetworkClient instance for the specified network
    * @throws Error if the network is not supported
@@ -216,6 +258,14 @@ export class ClientFactory {
       const ClientClass = SOLANA_REGISTRY[network];
       if (!ClientClass) {
         throw new Error(`Unsupported Solana network: ${network}`);
+      }
+      return new ClientClass(config);
+    }
+
+    if (isZcashNetwork(network)) {
+      const ClientClass = ZCASH_REGISTRY[network];
+      if (!ClientClass) {
+        throw new Error(`Unsupported Zcash network: ${network}`);
       }
       return new ClientClass(config);
     }
@@ -239,9 +289,9 @@ export class ClientFactory {
    * Create a type-specific network client for the specified network
    * Automatically infers the correct client type based on the network identifier
    *
-   * @param network - The network identifier (EVM chain ID, Bitcoin or Solana CAIP-2 chain ID)
+   * @param network - The network identifier (EVM chain ID, or Bitcoin, Zcash or Solana CAIP-2 chain ID)
    * @param config - Strategy configuration with RPC URLs and strategy type
-   * @returns Typed client instance (e.g., SolanaClient for SOLANA_MAINNET, BitcoinClient for BITCOIN_MAINNET)
+   * @returns Typed client instance (e.g., SolanaClient for SOLANA_MAINNET, ZcashClient for ZCASH_MAINNET)
    * @throws Error if the network is not supported
    */
   static createTypedClient<T extends SupportedNetwork>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -297,6 +297,65 @@ export type {
   BtcBlockFilter,
 } from "./networks/bitcoin/BitcoinTypes.js";
 
+// Zcash (CAIP-2 Chain IDs: bip122:*)
+export { ZcashClient } from "./networks/zcash/ZcashClient.js";
+export { ZCASH_MAINNET, ZCASH_TESTNET } from "./networks/zcash/ZcashTypes.js";
+export type {
+  ZcashChainId,
+  ZecHashOrHeight,
+  ZecValuePoolId,
+  ZecUpgradeStatus,
+  ZecValuePoolBalance,
+  ZecChainSupply,
+  ZecNetworkUpgradeInfo,
+  ZecTipConsensusBranch,
+  ZecBlockchainInfo,
+  ZecBlockHeightAndHash,
+  ZecBlockTrees,
+  ZecBlockHeader,
+  ZecBlock,
+  ZecBlockVerbose,
+  ZecScriptSig,
+  ZecScriptPubKey,
+  ZecVin,
+  ZecVout,
+  ZecShieldedSpend,
+  ZecShieldedOutput,
+  ZecOrchardAction,
+  ZecOrchardBundle,
+  ZecJoinSplit,
+  ZecRawTransaction,
+  ZecTxOut,
+  ZecMempoolInfo,
+  ZecMempoolEntry,
+  ZecAddressRequest,
+  ZecAddressTxIdsRequest,
+  ZecAddressBalance,
+  ZecAddressUtxo,
+  ZecTreestatePool,
+  ZecTreestate,
+  ZecSubtree,
+  ZecSubtrees,
+  ZecUnifiedReceivers,
+  ZecValidateAddress,
+  ZecZValidateAddress,
+  ZecInfo,
+  ZecDeprecationInfo,
+  ZecNetwork,
+  ZecLocalAddress,
+  ZecNetworkInfo,
+  ZecPeerInfo,
+  ZecMiningInfo,
+  ZecFundingStream,
+  ZecBlockSubsidy,
+  ZecStandardFee,
+  ZecBlockTemplateTransaction,
+  ZecBlockTemplateCoinbase,
+  ZecBlockTemplate,
+  ZecBlockTemplateRequest,
+  ZecSubmitBlockResult,
+} from "./networks/zcash/ZcashTypes.js";
+
 // Solana (CAIP-2 Chain IDs: solana:*)
 export { SolanaClient } from "./networks/solana/SolanaClient.js";
 export {
@@ -361,6 +420,7 @@ export { ClientFactory } from "./factory/ClientRegistry.js";
 export type {
   SupportedChainId,
   SupportedBitcoinChainId,
+  SupportedZcashChainId,
   SupportedSolanaChainId,
   SupportedNetwork,
   ClientConstructor,
@@ -370,7 +430,7 @@ export type {
 
 // Strategy types and factory
 export { StrategyFactory } from "./strategies/requestStrategy.js";
-export type { StrategyConfig } from "./strategies/requestStrategy.js";
+export type { StrategyConfig, RpcEndpoint } from "./strategies/requestStrategy.js";
 export type {
   RequestStrategy,
   StrategyResult,

--- a/src/networks/solana/SolanaClient.ts
+++ b/src/networks/solana/SolanaClient.ts
@@ -85,7 +85,9 @@ export class SolanaClient extends NetworkClient {
   constructor(config: StrategyConfig) {
     super(config);
     this.subscriptionWsUrl =
-      config.rpcUrls.find((url) => url.startsWith("wss://") || url.startsWith("ws://")) ?? null;
+      config.rpcUrls
+        .map((endpoint) => (typeof endpoint === "string" ? endpoint : endpoint.url))
+        .find((url) => url.startsWith("wss://") || url.startsWith("ws://")) ?? null;
   }
 
   private getSubscriptionWs(): WebSocketRpcClient {

--- a/src/networks/zcash/ZcashClient.ts
+++ b/src/networks/zcash/ZcashClient.ts
@@ -1,0 +1,460 @@
+/**
+ * Zcash RPC Client (Zebra / zebrad)
+ *
+ * Provides typed methods for the Zcash JSON-RPC API as served by Zebra.
+ * Supports mainnet and testnet.
+ *
+ * Zebra's RPC server is HTTP-only, so — unlike the EVM and Solana clients —
+ * there is no WebSocket transport or subscription support for Zcash.
+ *
+ * All methods return StrategyResult<T> for consistent error handling.
+ *
+ * @see https://zebra.zfnd.org/
+ * @see https://docs.rs/zebra-rpc/latest/zebra_rpc/methods/
+ */
+
+import { NetworkClient } from "../../NetworkClient.js";
+import type { StrategyResult } from "../../strategies/strategiesTypes.js";
+import type {
+  ZecAddressBalance,
+  ZecAddressRequest,
+  ZecAddressTxIdsRequest,
+  ZecAddressUtxo,
+  ZecBlock,
+  ZecBlockHeader,
+  ZecBlockHeightAndHash,
+  ZecBlockSubsidy,
+  ZecBlockTemplate,
+  ZecBlockTemplateRequest,
+  ZecBlockVerbose,
+  ZecBlockchainInfo,
+  ZecDeprecationInfo,
+  ZecHashOrHeight,
+  ZecInfo,
+  ZecMempoolEntry,
+  ZecMempoolInfo,
+  ZecMiningInfo,
+  ZecNetworkInfo,
+  ZecPeerInfo,
+  ZecRawTransaction,
+  ZecStandardFee,
+  ZecSubmitBlockResult,
+  ZecSubtrees,
+  ZecTreestate,
+  ZecTxOut,
+  ZecUnifiedReceivers,
+  ZecValidateAddress,
+  ZecZValidateAddress,
+} from "./ZcashTypes.js";
+
+export class ZcashClient extends NetworkClient {
+  // ===== Chain & Blocks =====
+
+  /**
+   * Returns various state info regarding blockchain processing
+   */
+  async getBlockchainInfo(): Promise<StrategyResult<ZecBlockchainInfo>> {
+    return this.execute<ZecBlockchainInfo>("getblockchaininfo");
+  }
+
+  /**
+   * Returns the height of the most-work fully-validated chain
+   */
+  async getBlockCount(): Promise<StrategyResult<number>> {
+    return this.execute<number>("getblockcount");
+  }
+
+  /**
+   * Returns the hash of the best (tip) block in the best chain
+   */
+  async getBestBlockHash(): Promise<StrategyResult<string>> {
+    return this.execute<string>("getbestblockhash");
+  }
+
+  /**
+   * Returns the height and hash of the best block in a single call
+   */
+  async getBestBlockHeightAndHash(): Promise<StrategyResult<ZecBlockHeightAndHash>> {
+    return this.execute<ZecBlockHeightAndHash>("getbestblockheightandhash");
+  }
+
+  /**
+   * Returns the hash of the block at the given height
+   * @param index - Block height. Negative values count back from the tip.
+   */
+  async getBlockHash(index: number): Promise<StrategyResult<string>> {
+    return this.execute<string>("getblockhash", [index]);
+  }
+
+  /**
+   * Returns block data
+   * @param hashOrHeight - Block hash, or height as a decimal string (e.g. "3444000")
+   * @param verbosity - 0 = hex, 1 = JSON with txids (default), 2 = JSON with full transactions
+   */
+  async getBlock(hashOrHeight: ZecHashOrHeight, verbosity: 0): Promise<StrategyResult<string>>;
+  async getBlock(hashOrHeight: ZecHashOrHeight, verbosity?: 1): Promise<StrategyResult<ZecBlock>>;
+  async getBlock(
+    hashOrHeight: ZecHashOrHeight,
+    verbosity: 2,
+  ): Promise<StrategyResult<ZecBlockVerbose>>;
+  async getBlock(
+    hashOrHeight: ZecHashOrHeight,
+    verbosity: 0 | 1 | 2 = 1,
+  ): Promise<StrategyResult<string | ZecBlock | ZecBlockVerbose>> {
+    return this.execute("getblock", [hashOrHeight, verbosity]);
+  }
+
+  /**
+   * Returns the block header
+   * @param hashOrHeight - Block hash, or height as a decimal string
+   * @param verbose - false returns hex, true returns a JSON object (default)
+   */
+  async getBlockHeader(
+    hashOrHeight: ZecHashOrHeight,
+    verbose: false,
+  ): Promise<StrategyResult<string>>;
+  async getBlockHeader(
+    hashOrHeight: ZecHashOrHeight,
+    verbose?: true,
+  ): Promise<StrategyResult<ZecBlockHeader>>;
+  async getBlockHeader(
+    hashOrHeight: ZecHashOrHeight,
+    verbose = true,
+  ): Promise<StrategyResult<string | ZecBlockHeader>> {
+    return this.execute("getblockheader", [hashOrHeight, verbose]);
+  }
+
+  /**
+   * Returns the proof-of-work difficulty as a multiple of the minimum difficulty
+   */
+  async getDifficulty(): Promise<StrategyResult<number>> {
+    return this.execute<number>("getdifficulty");
+  }
+
+  // ===== Transactions =====
+
+  /**
+   * Returns raw transaction data
+   * @param txid - The transaction ID
+   * @param verbose - 0 returns hex (default), 1 returns a JSON object
+   * @param blockHash - Optional block hash to look the transaction up in
+   */
+  async getRawTransaction(
+    txid: string,
+    verbose: 0,
+    blockHash?: string,
+  ): Promise<StrategyResult<string>>;
+  async getRawTransaction(
+    txid: string,
+    verbose: 1,
+    blockHash?: string,
+  ): Promise<StrategyResult<ZecRawTransaction>>;
+  async getRawTransaction(
+    txid: string,
+    verbose: 0 | 1 = 0,
+    blockHash?: string,
+  ): Promise<StrategyResult<string | ZecRawTransaction>> {
+    const params: (string | number)[] = [txid, verbose];
+    if (blockHash !== undefined) params.push(blockHash);
+    return this.execute("getrawtransaction", params);
+  }
+
+  /**
+   * Submits a raw transaction (serialized, hex-encoded) to the network
+   * @param hexString - The hex-encoded raw transaction
+   * @param allowHighFees - Whether to allow unusually high fees
+   * @returns The transaction ID
+   */
+  async sendRawTransaction(
+    hexString: string,
+    allowHighFees?: boolean,
+  ): Promise<StrategyResult<string>> {
+    const params: (string | boolean)[] = [hexString];
+    if (allowHighFees !== undefined) params.push(allowHighFees);
+    return this.execute<string>("sendrawtransaction", params);
+  }
+
+  /**
+   * Returns details about an unspent transaction output
+   * @param txid - The transaction ID
+   * @param n - The output index (vout)
+   * @param includeMempool - Whether to include the mempool (default true)
+   */
+  async getTxOut(
+    txid: string,
+    n: number,
+    includeMempool?: boolean,
+  ): Promise<StrategyResult<ZecTxOut | null>> {
+    const params: (string | number | boolean)[] = [txid, n];
+    if (includeMempool !== undefined) params.push(includeMempool);
+    return this.execute<ZecTxOut | null>("gettxout", params);
+  }
+
+  // ===== Mempool =====
+
+  /**
+   * Returns details on the active state of the transaction memory pool
+   */
+  async getMempoolInfo(): Promise<StrategyResult<ZecMempoolInfo>> {
+    return this.execute<ZecMempoolInfo>("getmempoolinfo");
+  }
+
+  /**
+   * Returns all transaction IDs in the memory pool
+   * @param verbose - false returns an array of txids (default), true returns detailed entries
+   */
+  async getRawMempool(verbose?: false): Promise<StrategyResult<string[]>>;
+  async getRawMempool(verbose: true): Promise<StrategyResult<Record<string, ZecMempoolEntry>>>;
+  async getRawMempool(
+    verbose = false,
+  ): Promise<StrategyResult<string[] | Record<string, ZecMempoolEntry>>> {
+    return this.execute("getrawmempool", [verbose]);
+  }
+
+  // ===== Address Index =====
+
+  /**
+   * Returns the balance for the given transparent addresses
+   *
+   * Requires the node to be running with an address index.
+   * @param request - Object bag of the form `{ addresses: ["t1..."] }`
+   */
+  async getAddressBalance(request: ZecAddressRequest): Promise<StrategyResult<ZecAddressBalance>> {
+    return this.execute<ZecAddressBalance>("getaddressbalance", [request]);
+  }
+
+  /**
+   * Returns the transaction IDs involving the given transparent addresses
+   * @param request - Object bag of the form `{ addresses, start, end }`
+   */
+  async getAddressTxIds(request: ZecAddressTxIdsRequest): Promise<StrategyResult<string[]>> {
+    return this.execute<string[]>("getaddresstxids", [request]);
+  }
+
+  /**
+   * Returns all unspent outputs for the given transparent addresses
+   * @param request - Object bag of the form `{ addresses: ["t1..."] }`
+   */
+  async getAddressUtxos(request: ZecAddressRequest): Promise<StrategyResult<ZecAddressUtxo[]>> {
+    return this.execute<ZecAddressUtxo[]>("getaddressutxos", [request]);
+  }
+
+  // ===== Shielded Pools =====
+
+  /**
+   * Returns the Sapling and Orchard note commitment tree state at the given block
+   * @param hashOrHeight - Block hash, or height as a decimal string
+   */
+  async zGetTreestate(hashOrHeight: ZecHashOrHeight): Promise<StrategyResult<ZecTreestate>> {
+    return this.execute<ZecTreestate>("z_gettreestate", [hashOrHeight]);
+  }
+
+  /**
+   * Returns note commitment subtrees for a shielded pool
+   * @param pool - "sapling" or "orchard"
+   * @param startIndex - The subtree index to start from
+   * @param limit - Maximum number of subtrees to return
+   */
+  async zGetSubtreesByIndex(
+    pool: string,
+    startIndex: number,
+    limit?: number,
+  ): Promise<StrategyResult<ZecSubtrees>> {
+    const params: (string | number)[] = [pool, startIndex];
+    if (limit !== undefined) params.push(limit);
+    return this.execute<ZecSubtrees>("z_getsubtreesbyindex", params);
+  }
+
+  /**
+   * Returns the individual receivers contained in a unified address
+   * @param address - A unified address (u1...)
+   */
+  async zListUnifiedReceivers(address: string): Promise<StrategyResult<ZecUnifiedReceivers>> {
+    return this.execute<ZecUnifiedReceivers>("z_listunifiedreceivers", [address]);
+  }
+
+  // ===== Address Validation =====
+
+  /**
+   * Validates a transparent address
+   * @param address - The transparent address to validate (t1.../t3...)
+   */
+  async validateAddress(address: string): Promise<StrategyResult<ZecValidateAddress>> {
+    return this.execute<ZecValidateAddress>("validateaddress", [address]);
+  }
+
+  /**
+   * Validates a shielded or unified address
+   * @param address - The shielded (zs.../zc...) or unified (u1...) address to validate
+   */
+  async zValidateAddress(address: string): Promise<StrategyResult<ZecZValidateAddress>> {
+    return this.execute<ZecZValidateAddress>("z_validateaddress", [address]);
+  }
+
+  // ===== Mining =====
+
+  /**
+   * Returns data needed to construct a block to work on
+   * @param request - Optional template request parameters
+   */
+  async getBlockTemplate(
+    request?: ZecBlockTemplateRequest,
+  ): Promise<StrategyResult<ZecBlockTemplate>> {
+    const params: ZecBlockTemplateRequest[] = [];
+    if (request !== undefined) params.push(request);
+    return this.execute<ZecBlockTemplate>("getblocktemplate", params);
+  }
+
+  /**
+   * Submits a new block to the network
+   * @param hexData - The hex-encoded block data
+   * @param parameters - Optional extra parameters (ignored by Zebra)
+   * @returns null on success, otherwise a rejection reason
+   */
+  async submitBlock(
+    hexData: string,
+    parameters?: Record<string, string>,
+  ): Promise<StrategyResult<ZecSubmitBlockResult>> {
+    const params: (string | Record<string, string>)[] = [hexData];
+    if (parameters !== undefined) params.push(parameters);
+    return this.execute<ZecSubmitBlockResult>("submitblock", params);
+  }
+
+  /**
+   * Returns mining-related information
+   */
+  async getMiningInfo(): Promise<StrategyResult<ZecMiningInfo>> {
+    return this.execute<ZecMiningInfo>("getmininginfo");
+  }
+
+  /**
+   * Returns the estimated network solutions per second
+   * @param numBlocks - Number of blocks to average over (default 120)
+   * @param height - Estimate at the given height instead of the tip
+   */
+  async getNetworkSolPs(numBlocks?: number, height?: number): Promise<StrategyResult<number>> {
+    const params: number[] = [];
+    if (numBlocks !== undefined) params.push(numBlocks);
+    if (height !== undefined) params.push(height);
+    return this.execute<number>("getnetworksolps", params);
+  }
+
+  /**
+   * Returns the estimated network solutions per second
+   *
+   * @deprecated Zebra keeps this only for zcashd compatibility — prefer
+   * {@link ZcashClient.getNetworkSolPs}, which it delegates to.
+   */
+  async getNetworkHashPs(numBlocks?: number, height?: number): Promise<StrategyResult<number>> {
+    const params: number[] = [];
+    if (numBlocks !== undefined) params.push(numBlocks);
+    if (height !== undefined) params.push(height);
+    return this.execute<number>("getnetworkhashps", params);
+  }
+
+  /**
+   * Returns the block subsidy split into miner, funding stream and lockbox portions
+   * @param height - Block height to query (defaults to the next block)
+   */
+  async getBlockSubsidy(height?: number): Promise<StrategyResult<ZecBlockSubsidy>> {
+    const params: number[] = [];
+    if (height !== undefined) params.push(height);
+    return this.execute<ZecBlockSubsidy>("getblocksubsidy", params);
+  }
+
+  /**
+   * Returns the standard (conventional) fee for the current network upgrade
+   */
+  async getStandardFee(): Promise<StrategyResult<ZecStandardFee>> {
+    return this.execute<ZecStandardFee>("getstandardfee");
+  }
+
+  /**
+   * Mines blocks immediately (regtest only)
+   * @param numBlocks - Number of blocks to generate
+   * @returns The hashes of the generated blocks
+   */
+  async generate(numBlocks: number): Promise<StrategyResult<string[]>> {
+    return this.execute<string[]>("generate", [numBlocks]);
+  }
+
+  /**
+   * Mines blocks immediately to a given address (regtest only)
+   * @param numBlocks - Number of blocks to generate
+   * @param address - The address to send the coinbase to
+   */
+  async generateToAddress(numBlocks: number, address: string): Promise<StrategyResult<string[]>> {
+    return this.execute<string[]>("generatetoaddress", [numBlocks, address]);
+  }
+
+  // ===== Node & Network =====
+
+  /**
+   * Returns general information about the node and network
+   */
+  async getInfo(): Promise<StrategyResult<ZecInfo>> {
+    return this.execute<ZecInfo>("getinfo");
+  }
+
+  /**
+   * Returns deprecation information for the running node
+   */
+  async getDeprecationInfo(): Promise<StrategyResult<ZecDeprecationInfo>> {
+    return this.execute<ZecDeprecationInfo>("getdeprecationinfo");
+  }
+
+  /**
+   * Returns information about the node's network connections
+   */
+  async getNetworkInfo(): Promise<StrategyResult<ZecNetworkInfo>> {
+    return this.execute<ZecNetworkInfo>("getnetworkinfo");
+  }
+
+  /**
+   * Returns data about each connected network peer
+   */
+  async getPeerInfo(): Promise<StrategyResult<ZecPeerInfo[]>> {
+    return this.execute<ZecPeerInfo[]>("getpeerinfo");
+  }
+
+  /**
+   * Requests that a ping be sent to all other nodes, to measure ping time
+   */
+  async ping(): Promise<StrategyResult<null>> {
+    return this.execute<null>("ping");
+  }
+
+  /**
+   * Adds, removes or reconnects to a peer node
+   * @param addr - The peer address as "host:port"
+   * @param command - "add", "remove" or "onetry"
+   */
+  async addNode(addr: string, command: "add" | "remove" | "onetry"): Promise<StrategyResult<null>> {
+    return this.execute<null>("addnode", [addr, command]);
+  }
+
+  /**
+   * Requests a graceful shutdown of the node
+   */
+  async stop(): Promise<StrategyResult<string>> {
+    return this.execute<string>("stop");
+  }
+
+  // ===== Chain Manipulation =====
+
+  /**
+   * Permanently marks a block as invalid, as if it violated a consensus rule
+   * @param blockHash - The hash of the block to invalidate
+   */
+  async invalidateBlock(blockHash: string): Promise<StrategyResult<null>> {
+    return this.execute<null>("invalidateblock", [blockHash]);
+  }
+
+  /**
+   * Removes invalidity status from a block previously marked invalid
+   * @param blockHash - The hash of the block to reconsider
+   */
+  async reconsiderBlock(blockHash: string): Promise<StrategyResult<string[]>> {
+    return this.execute<string[]>("reconsiderblock", [blockHash]);
+  }
+}

--- a/src/networks/zcash/ZcashTypes.ts
+++ b/src/networks/zcash/ZcashTypes.ts
@@ -1,0 +1,695 @@
+/**
+ * Zcash RPC Types (Zebra / zebrad)
+ *
+ * Type definitions for the Zcash JSON-RPC API as served by Zebra, the Zcash
+ * Foundation's node implementation. Supports mainnet and testnet.
+ *
+ * Zebra supersedes `zcashd`, which reached its automatic end-of-support halt on
+ * 2026-07-18 and no longer runs. These types therefore model Zebra's RPC surface,
+ * not the historical `zcashd` surface.
+ *
+ * @see https://zebra.zfnd.org/
+ * @see https://docs.rs/zebra-rpc/latest/zebra_rpc/methods/
+ */
+
+// ===== Chain ID Constants (CAIP-2 format: bip122:<first-32-chars-of-genesis-hash>) =====
+
+/**
+ * CAIP-2 chain ID for Zcash Mainnet
+ * Format: bip122:<32-char-genesis-block-hash-prefix>
+ *
+ * Genesis: 00040fe8ec8471911baa1db1266ea15dd06b4a8a5c453883c000b031973dce08
+ */
+export const ZCASH_MAINNET = "bip122:00040fe8ec8471911baa1db1266ea15d" as const;
+
+/**
+ * CAIP-2 chain ID for Zcash Testnet
+ *
+ * Genesis: 05a60a92d99d85997cce3b87616c089f6124d7342af37106edc76126334a2c38
+ */
+export const ZCASH_TESTNET = "bip122:05a60a92d99d85997cce3b87616c089f" as const;
+
+/**
+ * Supported Zcash chain IDs (CAIP-2 format)
+ */
+export type ZcashChainId = typeof ZCASH_MAINNET | typeof ZCASH_TESTNET;
+
+// ===== Common types =====
+
+/**
+ * A block hash or a block height. Zebra accepts both as a string, so a height
+ * must be passed as a decimal string (e.g. "3444000"), not a number.
+ */
+export type ZecHashOrHeight = string;
+
+/**
+ * Shielded value pool identifiers, in the order Zcash introduced them
+ */
+export type ZecValuePoolId =
+  | "transparent"
+  | "sprout"
+  | "sapling"
+  | "orchard"
+  | "lockbox"
+  | "ironwood";
+
+/**
+ * Activation status of a network upgrade
+ */
+export type ZecUpgradeStatus = "active" | "pending";
+
+// ===== Chain / blockchain info =====
+
+/**
+ * Balance of a single shielded or transparent value pool
+ */
+export interface ZecValuePoolBalance {
+  id: ZecValuePoolId;
+  /** Pool balance in ZEC */
+  chainValue: number;
+  /** Pool balance in zatoshis (1 ZEC = 100_000_000 zat) */
+  chainValueZat: number;
+  monitored: boolean;
+}
+
+/**
+ * Total chain supply, using the same shape as a value pool minus the id
+ */
+export interface ZecChainSupply {
+  chainValue: number;
+  chainValueZat: number;
+  monitored: boolean;
+}
+
+/**
+ * A network upgrade entry, keyed in `upgrades` by its consensus branch ID
+ */
+export interface ZecNetworkUpgradeInfo {
+  name: string;
+  activationheight: number;
+  status: ZecUpgradeStatus;
+}
+
+/**
+ * Consensus branch IDs for the current tip and the next block
+ */
+export interface ZecTipConsensusBranch {
+  chaintip: string;
+  nextblock: string;
+}
+
+/**
+ * Response from getblockchaininfo
+ */
+export interface ZecBlockchainInfo {
+  /** Network name: "main", "test" or "regtest" */
+  chain: string;
+  blocks: number;
+  headers: number;
+  difficulty: number;
+  verificationprogress: number;
+  chainwork: number;
+  pruned: boolean;
+  size_on_disk: number;
+  commitments: number;
+  bestblockhash: string;
+  estimatedheight: number;
+  chainSupply: ZecChainSupply;
+  valuePools: ZecValuePoolBalance[];
+  /** Network upgrades keyed by consensus branch ID hex */
+  upgrades: Record<string, ZecNetworkUpgradeInfo>;
+  consensus: ZecTipConsensusBranch;
+}
+
+/**
+ * Response from getbestblockheightandhash
+ */
+export interface ZecBlockHeightAndHash {
+  height: number;
+  hash: string;
+}
+
+// ===== Blocks =====
+
+/**
+ * Sapling / Orchard note commitment tree sizes for a block
+ */
+export interface ZecBlockTrees {
+  sapling?: { size: number };
+  orchard?: { size: number };
+}
+
+/**
+ * Fields shared by getblockheader (verbose) and getblock (verbosity >= 1)
+ */
+export interface ZecBlockHeader {
+  hash: string;
+  confirmations: number;
+  height: number;
+  version: number;
+  merkleroot: string;
+  /** Block commitments hash (hashBlockCommitments), NU5 onwards */
+  blockcommitments: string;
+  finalsaplingroot: string;
+  /** Only present on post-NU5 blocks */
+  finalorchardroot?: string;
+  time: number;
+  /** 32-byte hex string, unlike Bitcoin's numeric nonce */
+  nonce: string;
+  /** Equihash solution, hex-encoded — Zcash specific */
+  solution: string;
+  bits: string;
+  difficulty: number;
+  chainwork?: string;
+  previousblockhash?: string;
+  nextblockhash?: string;
+}
+
+/**
+ * Fields getblock adds on top of the block header, at any verbosity >= 1
+ */
+interface ZecBlockCommon extends ZecBlockHeader {
+  size?: number;
+  nTx?: number;
+  trees?: ZecBlockTrees;
+  /** Total chain supply as of this block */
+  chainSupply?: ZecChainSupply;
+  /** Per-pool balances as of this block */
+  valuePools?: ZecValuePoolBalance[];
+}
+
+/**
+ * Response from getblock with verbosity 1 (transaction IDs only)
+ */
+export interface ZecBlock extends ZecBlockCommon {
+  tx: string[];
+}
+
+/**
+ * Response from getblock with verbosity 2 (full transaction objects)
+ */
+export interface ZecBlockVerbose extends ZecBlockCommon {
+  tx: ZecRawTransaction[];
+}
+
+// ===== Transactions =====
+
+/**
+ * Script signature of a transparent input
+ */
+export interface ZecScriptSig {
+  asm: string;
+  hex: string;
+}
+
+/**
+ * Output script of a transparent output
+ */
+export interface ZecScriptPubKey {
+  asm: string;
+  hex: string;
+  reqSigs?: number;
+  type: string;
+  addresses?: string[];
+}
+
+/**
+ * Transparent transaction input
+ */
+export interface ZecVin {
+  txid?: string;
+  vout?: number;
+  scriptSig?: ZecScriptSig;
+  /** Present instead of txid/vout on coinbase inputs */
+  coinbase?: string;
+  sequence: number;
+  value?: number;
+  valueZat?: number;
+  address?: string;
+}
+
+/**
+ * Transparent transaction output
+ */
+export interface ZecVout {
+  /** Value in ZEC */
+  value: number;
+  /** Value in zatoshis */
+  valueZat?: number;
+  n: number;
+  scriptPubKey: ZecScriptPubKey;
+}
+
+/**
+ * Sapling shielded spend description
+ */
+export interface ZecShieldedSpend {
+  cv: string;
+  anchor: string;
+  nullifier: string;
+  rk: string;
+  proof: string;
+  spendAuthSig: string;
+}
+
+/**
+ * Sapling shielded output description
+ */
+export interface ZecShieldedOutput {
+  cv: string;
+  cmu: string;
+  ephemeralKey: string;
+  encCiphertext: string;
+  outCiphertext: string;
+  proof: string;
+}
+
+/**
+ * Orchard action (combined spend and output), NU5 onwards
+ */
+export interface ZecOrchardAction {
+  cv: string;
+  nullifier: string;
+  rk: string;
+  cmx: string;
+  ephemeralKey: string;
+  encCiphertext: string;
+  spendAuthSig: string;
+  outCiphertext: string;
+}
+
+/**
+ * Orchard bundle attached to a transaction
+ */
+export interface ZecOrchardBundle {
+  actions: ZecOrchardAction[];
+  valueBalance?: number;
+  valueBalanceZat?: number;
+}
+
+/**
+ * Sprout-era JoinSplit description
+ */
+export interface ZecJoinSplit {
+  vpub_old: number;
+  vpub_new: number;
+  vpub_oldZat?: number;
+  vpub_newZat?: number;
+  anchor: string;
+  nullifiers: string[];
+  commitments: string[];
+  onetimePubKey: string;
+  randomSeed: string;
+  macs: string[];
+  proof: string;
+  ciphertexts: string[];
+}
+
+/**
+ * Response from getrawtransaction with verbose 1
+ */
+export interface ZecRawTransaction {
+  in_active_chain?: boolean;
+  hex: string;
+  txid?: string;
+  authdigest?: string;
+  size?: number;
+  overwintered?: boolean;
+  version?: number;
+  versiongroupid?: string;
+  locktime?: number;
+  expiryheight?: number;
+  vin: ZecVin[];
+  vout: ZecVout[];
+  /** Net value moved into (negative) or out of (positive) the Sapling pool, in ZEC */
+  valueBalance?: number;
+  valueBalanceZat?: number;
+  vShieldedSpend?: ZecShieldedSpend[];
+  vShieldedOutput?: ZecShieldedOutput[];
+  bindingSig?: string;
+  orchard?: ZecOrchardBundle;
+  vjoinsplit?: ZecJoinSplit[];
+  joinSplitPubKey?: string;
+  joinSplitSig?: string;
+  blockhash?: string;
+  height?: number;
+  confirmations?: number;
+  time?: number;
+  blocktime?: number;
+}
+
+/**
+ * Response from gettxout
+ */
+export interface ZecTxOut {
+  bestblock: string;
+  confirmations: number;
+  /** Value in ZEC */
+  value: number;
+  scriptPubKey: ZecScriptPubKey;
+  version: number;
+  coinbase: boolean;
+}
+
+// ===== Mempool =====
+
+/**
+ * Response from getmempoolinfo
+ */
+export interface ZecMempoolInfo {
+  size: number;
+  bytes: number;
+  usage: number;
+}
+
+/**
+ * A verbose mempool entry, returned by getrawmempool with verbose = true
+ */
+export interface ZecMempoolEntry {
+  size: number;
+  fee: number;
+  modifiedfee: number;
+  time: number;
+  height: number;
+  descendantcount: number;
+  descendantsize: number;
+  descendantfees: number;
+  depends: string[];
+}
+
+// ===== Address index =====
+
+/**
+ * Request bag for getaddressbalance and getaddressutxos
+ */
+export interface ZecAddressRequest {
+  addresses: string[];
+}
+
+/**
+ * Request bag for getaddresstxids
+ */
+export interface ZecAddressTxIdsRequest {
+  addresses: string[];
+  start?: number;
+  end?: number;
+}
+
+/**
+ * Response from getaddressbalance
+ */
+export interface ZecAddressBalance {
+  /** Balance in zatoshis */
+  balance: number;
+  received?: number;
+}
+
+/**
+ * A single UTXO returned by getaddressutxos
+ */
+export interface ZecAddressUtxo {
+  address: string;
+  txid: string;
+  outputIndex: number;
+  script: string;
+  /** Value in zatoshis */
+  satoshis: number;
+  height: number;
+}
+
+// ===== Shielded pools =====
+
+/**
+ * State of a single note commitment tree at a given block
+ */
+export interface ZecTreestatePool {
+  /** Hex-encoded note commitment tree state */
+  commitments: {
+    finalState: string;
+  };
+  skipHash?: string;
+}
+
+/**
+ * Response from z_gettreestate
+ */
+export interface ZecTreestate {
+  hash: string;
+  height: number;
+  time: number;
+  sapling?: ZecTreestatePool;
+  orchard?: ZecTreestatePool;
+}
+
+/**
+ * A single note commitment subtree
+ */
+export interface ZecSubtree {
+  root: string;
+  end_height: number;
+}
+
+/**
+ * Response from z_getsubtreesbyindex
+ */
+export interface ZecSubtrees {
+  pool: string;
+  start_index: number;
+  subtrees: ZecSubtree[];
+}
+
+/**
+ * Response from z_listunifiedreceivers — each field is present only if the
+ * unified address contains a receiver of that type
+ */
+export interface ZecUnifiedReceivers {
+  orchard?: string;
+  sapling?: string;
+  p2pkh?: string;
+  p2sh?: string;
+}
+
+// ===== Address validation =====
+
+/**
+ * Response from validateaddress (transparent addresses)
+ */
+export interface ZecValidateAddress {
+  isvalid: boolean;
+  address?: string;
+  scriptPubKey?: string;
+  isscript?: boolean;
+}
+
+/**
+ * Response from z_validateaddress (shielded and unified addresses)
+ */
+export interface ZecZValidateAddress {
+  isvalid: boolean;
+  address?: string;
+  /** "sprout", "sapling" or "unified" */
+  address_type?: string;
+  ismine?: boolean;
+  payingkey?: string;
+  transmissionkey?: string;
+  diversifier?: string;
+  diversifiedtransmissionkey?: string;
+}
+
+// ===== Node / network =====
+
+/**
+ * Response from getinfo
+ */
+export interface ZecInfo {
+  version: number;
+  build: string;
+  subversion: string;
+  protocolversion: number;
+  blocks: number;
+  connections: number;
+  proxy?: string;
+  difficulty: number;
+  testnet: boolean;
+  paytxfee: number;
+  relayfee: number;
+  errors: string;
+  errorstimestamp: number;
+}
+
+/**
+ * Response from getdeprecationinfo
+ */
+export interface ZecDeprecationInfo {
+  version: number;
+  subversion: string;
+  deprecationheight: number;
+  end_of_service: {
+    block_height: number;
+    estimated_time: number;
+  };
+}
+
+/**
+ * A network stanza inside getnetworkinfo
+ */
+export interface ZecNetwork {
+  name: string;
+  limited: boolean;
+  reachable: boolean;
+  proxy: string;
+  proxy_randomize_credentials: boolean;
+}
+
+/**
+ * A local address stanza inside getnetworkinfo
+ */
+export interface ZecLocalAddress {
+  address: string;
+  port: number;
+  score: number;
+}
+
+/**
+ * Response from getnetworkinfo
+ */
+export interface ZecNetworkInfo {
+  version: number;
+  subversion: string;
+  protocolversion: number;
+  localservices: string;
+  timeoffset: number;
+  connections: number;
+  networks: ZecNetwork[];
+  relayfee: number;
+  localaddresses: ZecLocalAddress[];
+  warnings: string;
+}
+
+/**
+ * A single peer entry from getpeerinfo
+ */
+export interface ZecPeerInfo {
+  addr: string;
+  inbound: boolean;
+}
+
+// ===== Mining =====
+
+/**
+ * Response from getmininginfo
+ */
+export interface ZecMiningInfo {
+  blocks: number;
+  currentblocksize?: number;
+  currentblocktx?: number;
+  difficulty?: number;
+  errors?: string;
+  genproclimit?: number;
+  networksolps: number;
+  networkhashps: number;
+  pooledtx?: number;
+  testnet: boolean;
+  chain: string;
+  generate?: boolean;
+}
+
+/**
+ * A funding stream or lockbox entry inside getblocksubsidy
+ */
+export interface ZecFundingStream {
+  recipient: string;
+  specification: string;
+  /** Value in ZEC */
+  value: number;
+  valueZat: number;
+  address?: string;
+}
+
+/**
+ * Response from getblocksubsidy
+ */
+export interface ZecBlockSubsidy {
+  fundingstreams?: ZecFundingStream[];
+  lockboxstreams?: ZecFundingStream[];
+  /** Miner subsidy in ZEC */
+  miner: number;
+  founders?: number;
+  fundingstreamstotal?: number;
+  lockboxtotal?: number;
+  totalblocksubsidy?: number;
+}
+
+/**
+ * Response from getstandardfee
+ */
+export type ZecStandardFee = number;
+
+/**
+ * A transaction entry inside a block template
+ */
+export interface ZecBlockTemplateTransaction {
+  data: string;
+  hash: string;
+  authdigest?: string;
+  depends: number[];
+  fee: number;
+  sigops: number;
+  required?: boolean;
+}
+
+/**
+ * Coinbase transaction entry inside a block template
+ */
+export interface ZecBlockTemplateCoinbase {
+  data: string;
+  hash: string;
+  authdigest?: string;
+  depends: number[];
+  fee: number;
+  sigops: number;
+  required: boolean;
+}
+
+/**
+ * Response from getblocktemplate (in the default "template" mode)
+ */
+export interface ZecBlockTemplate {
+  capabilities: string[];
+  version: number;
+  previousblockhash: string;
+  blockcommitmentshash?: string;
+  lightclientroothash?: string;
+  finalsaplingroothash?: string;
+  defaultroots?: Record<string, string>;
+  transactions: ZecBlockTemplateTransaction[];
+  coinbasetxn: ZecBlockTemplateCoinbase;
+  longpollid: string;
+  target: string;
+  mintime: number;
+  mutable: string[];
+  noncerange: string;
+  sigoplimit: number;
+  sizelimit: number;
+  curtime: number;
+  bits: string;
+  height: number;
+  maxtime?: number;
+  submitold?: boolean;
+}
+
+/**
+ * Optional parameters for getblocktemplate
+ */
+export interface ZecBlockTemplateRequest {
+  mode?: "template" | "proposal";
+  data?: string;
+  capabilities?: string[];
+  longpollid?: string;
+  _proposal_hash?: string;
+}
+
+/**
+ * Result of submitblock — null on success, otherwise a rejection reason
+ */
+export type ZecSubmitBlockResult = string | null;

--- a/src/strategies/requestStrategy.ts
+++ b/src/strategies/requestStrategy.ts
@@ -2,11 +2,14 @@ import type { RequestStrategy } from "./strategiesTypes.js";
 import { FallbackStrategy } from "./fallbackStrategy.js";
 import { ParallelStrategy } from "./parallelStrategy.js";
 import { RaceStrategy } from "./raceStrategy.js";
-import { createTransport } from "../JsonRpcTransport.js";
+import { createTransport, type RpcEndpoint } from "../JsonRpcTransport.js";
+
+export type { RpcEndpoint };
 
 export interface StrategyConfig {
   type: "fallback" | "parallel" | "race";
-  rpcUrls: string[];
+  /** RPC endpoints — plain URL strings, or objects carrying per-endpoint headers */
+  rpcUrls: (string | RpcEndpoint)[];
 }
 
 export class StrategyFactory {
@@ -20,8 +23,8 @@ export class StrategyFactory {
       throw new Error("At least one RPC URL must be provided");
     }
 
-    // Create transports for each URL (auto-detects HTTP vs WebSocket from scheme)
-    const rpcClients = config.rpcUrls.map((url) => createTransport(url));
+    // Create transports for each endpoint (auto-detects HTTP vs WebSocket from scheme)
+    const rpcClients = config.rpcUrls.map((endpoint) => createTransport(endpoint));
 
     switch (config.type) {
       case "fallback":

--- a/tests/helpers/env.ts
+++ b/tests/helpers/env.ts
@@ -1,6 +1,7 @@
 import dotenvFlow from "dotenv-flow";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import type { RpcEndpoint } from "../../src/strategies/requestStrategy.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 dotenvFlow.config({ path: resolve(__dirname, "../..") });
@@ -34,3 +35,46 @@ export function getTestWsUrls(network: string, baseUrls: string[]): string[] {
   if (!subdomain) return baseUrls;
   return [...baseUrls, `wss://${subdomain}.g.alchemy.com/v2/${ALCHEMY_API_KEY}`];
 }
+
+const TATUM_API_KEY = process.env.TATUM_API_KEY;
+
+/**
+ * Whether a Tatum API key is configured.
+ *
+ * Without one, the Tatum gateway serves anonymous traffic capped at 5 requests
+ * per minute (shared across all its hosts), and whitelists only a subset of RPC
+ * methods. Tests that would exceed that budget should be skipped when this is false.
+ */
+export const hasTatumApiKey = Boolean(TATUM_API_KEY);
+
+/**
+ * Attach the Tatum API key to a gateway URL, if one is configured.
+ *
+ * Tatum authenticates via the `x-api-key` header — a key embedded in the URL path
+ * is silently ignored — so this returns an RpcEndpoint rather than a string when
+ * a key is present. Headers are scoped per endpoint, so the key is never sent to
+ * other providers in the same RPC URL list.
+ */
+export function withTatumKey(url: string): string | RpcEndpoint {
+  if (!TATUM_API_KEY) return url;
+  return { url, headers: { "x-api-key": TATUM_API_KEY } };
+}
+
+/**
+ * Zcash RPC endpoints for tests.
+ *
+ * Defaults to the public Tatum gateways (the only free no-key Zcash JSON-RPC
+ * available). Setting ZCASH_RPC_URL prepends a self-hosted zebrad or another
+ * provider, which takes priority under the fallback strategy.
+ */
+export function getZcashTestEndpoints(baseUrls: string[]): (string | RpcEndpoint)[] {
+  const endpoints = baseUrls.map(withTatumKey);
+  const override = process.env.ZCASH_RPC_URL;
+  return override ? [override, ...endpoints] : endpoints;
+}
+
+/**
+ * Whether a non-Tatum Zcash node is configured, which lifts both the rate limit
+ * and the gateway's method whitelist.
+ */
+export const hasZcashNodeUrl = Boolean(process.env.ZCASH_RPC_URL);

--- a/tests/http/factory/ClientFactory.test.ts
+++ b/tests/http/factory/ClientFactory.test.ts
@@ -10,6 +10,10 @@ import { ArbitrumClient } from "../../../src/networks/42161/ArbitrumClient.js";
 import { AztecClient } from "../../../src/networks/677868/AztecClient.js";
 import { SepoliaClient } from "../../../src/networks/11155111/SepoliaClient.js";
 import { SolanaClient } from "../../../src/networks/solana/SolanaClient.js";
+import { ZcashClient } from "../../../src/networks/zcash/ZcashClient.js";
+import { ZCASH_MAINNET, ZCASH_TESTNET } from "../../../src/networks/zcash/ZcashTypes.js";
+import { BitcoinClient } from "../../../src/networks/bitcoin/BitcoinClient.js";
+import { BITCOIN_MAINNET, BITCOIN_TESTNET3 } from "../../../src/networks/bitcoin/BitcoinTypes.js";
 import {
   SOLANA_MAINNET,
   SOLANA_DEVNET,
@@ -118,6 +122,58 @@ describe("ClientFactory - createClient", () => {
     assert.ok(client instanceof SolanaClient, "Should create SolanaClient instance");
     assert.strictEqual(client.getStrategyName(), "fallback", "Should use fallback strategy");
   });
+
+  it("should create ZcashClient for ZCASH_MAINNET", () => {
+    const client = ClientFactory.createClient(ZCASH_MAINNET, TEST_CONFIG);
+
+    assert.ok(client instanceof ZcashClient, "Should create ZcashClient instance");
+    assert.strictEqual(client.getStrategyName(), "fallback", "Should use fallback strategy");
+  });
+
+  it("should create ZcashClient for ZCASH_TESTNET", () => {
+    const client = ClientFactory.createClient(ZCASH_TESTNET, TEST_CONFIG);
+
+    assert.ok(client instanceof ZcashClient, "Should create ZcashClient instance");
+    assert.strictEqual(client.getStrategyName(), "fallback", "Should use fallback strategy");
+  });
+
+  it("should create BitcoinClient for BITCOIN_MAINNET", () => {
+    const client = ClientFactory.createClient(BITCOIN_MAINNET, TEST_CONFIG);
+
+    assert.ok(client instanceof BitcoinClient, "Should create BitcoinClient instance");
+    assert.strictEqual(client.getStrategyName(), "fallback", "Should use fallback strategy");
+  });
+});
+
+describe("ClientFactory - bip122 namespace routing", () => {
+  // Bitcoin and Zcash share the bip122: CAIP-2 namespace, so the factory must
+  // discriminate on registry membership rather than the namespace prefix.
+  it("should route Bitcoin and Zcash chain IDs to distinct clients", () => {
+    const bitcoin = ClientFactory.createClient(BITCOIN_MAINNET, TEST_CONFIG);
+    const zcash = ClientFactory.createClient(ZCASH_MAINNET, TEST_CONFIG);
+
+    assert.ok(bitcoin instanceof BitcoinClient, "Bitcoin ID should yield BitcoinClient");
+    assert.ok(zcash instanceof ZcashClient, "Zcash ID should yield ZcashClient");
+    assert.ok(!(bitcoin instanceof ZcashClient), "Bitcoin must not yield ZcashClient");
+    assert.ok(!(zcash instanceof BitcoinClient), "Zcash must not yield BitcoinClient");
+  });
+
+  it("should keep all bip122 testnet IDs routed to their own client", () => {
+    assert.ok(ClientFactory.createClient(BITCOIN_TESTNET3, TEST_CONFIG) instanceof BitcoinClient);
+    assert.ok(ClientFactory.createClient(ZCASH_TESTNET, TEST_CONFIG) instanceof ZcashClient);
+  });
+
+  it("should throw for an unregistered bip122 chain ID", () => {
+    assert.throws(
+      () =>
+        ClientFactory.createClient(
+          "bip122:ffffffffffffffffffffffffffffffff" as typeof ZCASH_MAINNET,
+          TEST_CONFIG,
+        ),
+      /Unsupported/,
+      "An unknown bip122 ID should be rejected rather than silently routed",
+    );
+  });
 });
 
 describe("ClientFactory - createTypedClient", () => {
@@ -175,6 +231,19 @@ describe("ClientFactory - createTypedClient", () => {
 
     assert.ok(client instanceof SepoliaClient, "Should create SepoliaClient instance");
     assert.strictEqual(client.getStrategyName(), "fallback", "Should use fallback strategy");
+  });
+
+  it("should create typed ZcashClient for ZCASH_MAINNET", () => {
+    const client = ClientFactory.createTypedClient(ZCASH_MAINNET, TEST_CONFIG);
+
+    assert.ok(client instanceof ZcashClient, "Should create ZcashClient instance");
+    // TypeScript should infer client as ZcashClient
+  });
+
+  it("should create typed BitcoinClient for BITCOIN_MAINNET", () => {
+    const client = ClientFactory.createTypedClient(BITCOIN_MAINNET, TEST_CONFIG);
+
+    assert.ok(client instanceof BitcoinClient, "Should create BitcoinClient instance");
   });
 
   it("should create typed SolanaClient for SOLANA_DEVNET", () => {

--- a/tests/http/networks/ZcashClient.test.ts
+++ b/tests/http/networks/ZcashClient.test.ts
@@ -1,0 +1,665 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { ZcashClient } from "../../../src/networks/zcash/ZcashClient.js";
+import { ZCASH_MAINNET, ZCASH_TESTNET } from "../../../src/networks/zcash/ZcashTypes.js";
+import type {
+  ZecBlock,
+  ZecBlockHeader,
+  ZecBlockVerbose,
+  ZecBlockchainInfo,
+  ZecMempoolInfo,
+  ZecNetworkInfo,
+  ZecRawTransaction,
+  ZecTxOut,
+  ZecValidateAddress,
+} from "../../../src/networks/zcash/ZcashTypes.js";
+import { ClientFactory } from "../../../src/factory/ClientRegistry.js";
+import { BitcoinClient } from "../../../src/networks/bitcoin/BitcoinClient.js";
+import { BITCOIN_MAINNET } from "../../../src/networks/bitcoin/BitcoinTypes.js";
+import type { StrategyConfig } from "../../../src/strategies/requestStrategy.js";
+import { getZcashTestEndpoints, hasTatumApiKey, hasZcashNodeUrl } from "../../helpers/env.js";
+
+// =============================================================================
+// Local validators
+//
+// tests/helpers/validators.ts is EVM/hex-oriented (0x-prefixed strings, addresses),
+// which does not apply to Zcash's Bitcoin-style decimal/hex-digest responses.
+// =============================================================================
+
+function assertObject(value: unknown, label: string): asserts value is Record<string, unknown> {
+  assert.ok(value !== null && typeof value === "object", `${label} should be an object`);
+}
+
+function assertString(value: unknown, label: string): asserts value is string {
+  assert.strictEqual(typeof value, "string", `${label} should be a string`);
+}
+
+function assertNumber(value: unknown, label: string): asserts value is number {
+  assert.strictEqual(typeof value, "number", `${label} should be a number`);
+  assert.ok(Number.isFinite(value), `${label} should be finite`);
+}
+
+function assertBoolean(value: unknown, label: string): asserts value is boolean {
+  assert.strictEqual(typeof value, "boolean", `${label} should be a boolean`);
+}
+
+/** A 64-char hex digest, the shape of every Zcash block hash and txid */
+function assertHash(value: unknown, label: string): asserts value is string {
+  assertString(value, label);
+  assert.match(value, /^[0-9a-f]{64}$/, `${label} should be a 64-char lowercase hex digest`);
+}
+
+function validateBlockchainInfo(info: ZecBlockchainInfo): void {
+  assertString(info.chain, "chain");
+  assertNumber(info.blocks, "blocks");
+  assertNumber(info.headers, "headers");
+  assertNumber(info.difficulty, "difficulty");
+  assertNumber(info.verificationprogress, "verificationprogress");
+  assertBoolean(info.pruned, "pruned");
+  assertNumber(info.estimatedheight, "estimatedheight");
+  assertHash(info.bestblockhash, "bestblockhash");
+
+  assertObject(info.chainSupply, "chainSupply");
+  assertNumber(info.chainSupply.chainValue, "chainSupply.chainValue");
+  assertNumber(info.chainSupply.chainValueZat, "chainSupply.chainValueZat");
+
+  assert.ok(Array.isArray(info.valuePools), "valuePools should be an array");
+  assert.ok(info.valuePools.length > 0, "valuePools should not be empty");
+  for (const pool of info.valuePools) {
+    assertString(pool.id, "valuePool.id");
+    assertNumber(pool.chainValue, "valuePool.chainValue");
+    assertNumber(pool.chainValueZat, "valuePool.chainValueZat");
+    assertBoolean(pool.monitored, "valuePool.monitored");
+  }
+
+  assertObject(info.upgrades, "upgrades");
+  for (const [branchId, upgrade] of Object.entries(info.upgrades)) {
+    assertString(branchId, "upgrade branch ID");
+    assertString(upgrade.name, "upgrade.name");
+    assertNumber(upgrade.activationheight, "upgrade.activationheight");
+    assertString(upgrade.status, "upgrade.status");
+  }
+
+  assertObject(info.consensus, "consensus");
+  assertString(info.consensus.chaintip, "consensus.chaintip");
+  assertString(info.consensus.nextblock, "consensus.nextblock");
+}
+
+function validateBlockHeader(header: ZecBlockHeader): void {
+  assertHash(header.hash, "hash");
+  assertNumber(header.confirmations, "confirmations");
+  assertNumber(header.height, "height");
+  assertNumber(header.version, "version");
+  assertHash(header.merkleroot, "merkleroot");
+  assertString(header.blockcommitments, "blockcommitments");
+  assertString(header.finalsaplingroot, "finalsaplingroot");
+  assertNumber(header.time, "time");
+  // Zcash-specific: nonce is a 32-byte hex string, not a number as in Bitcoin
+  assertString(header.nonce, "nonce");
+  assert.strictEqual(header.nonce.length, 64, "nonce should be 32 bytes of hex");
+  // Zcash-specific: Equihash solution
+  assertString(header.solution, "solution");
+  assert.ok(header.solution.length > 0, "solution should not be empty");
+  assertString(header.bits, "bits");
+  assertNumber(header.difficulty, "difficulty");
+}
+
+function validateBlock(block: ZecBlock): void {
+  validateBlockHeader(block);
+  assert.ok(Array.isArray(block.tx), "tx should be an array");
+  for (const txid of block.tx) {
+    assertHash(txid, "tx entry");
+  }
+}
+
+function validateRawTransaction(tx: ZecRawTransaction): void {
+  assertString(tx.hex, "hex");
+  assert.ok(Array.isArray(tx.vin), "vin should be an array");
+  assert.ok(Array.isArray(tx.vout), "vout should be an array");
+
+  for (const vin of tx.vin) {
+    assertNumber(vin.sequence, "vin.sequence");
+    // A transparent input has either a txid/vout pair or a coinbase field
+    assert.ok(
+      vin.txid !== undefined || vin.coinbase !== undefined,
+      "vin should carry either txid or coinbase",
+    );
+  }
+
+  for (const vout of tx.vout) {
+    assertNumber(vout.value, "vout.value");
+    assertNumber(vout.n, "vout.n");
+    assertObject(vout.scriptPubKey, "vout.scriptPubKey");
+    assertString(vout.scriptPubKey.asm, "scriptPubKey.asm");
+    assertString(vout.scriptPubKey.hex, "scriptPubKey.hex");
+    assertString(vout.scriptPubKey.type, "scriptPubKey.type");
+  }
+}
+
+// =============================================================================
+// Test configuration
+// =============================================================================
+
+// The only free no-key Zcash JSON-RPC endpoints. Both are Tatum hosts sharing a
+// single per-IP bucket of 5 req/min, so they buy redundancy rather than throughput.
+// A TATUM_API_KEY raises the ceiling; ZCASH_RPC_URL substitutes another node.
+const TEST_ENDPOINTS = getZcashTestEndpoints([
+  "https://zcash-mainnet-zebrad.gateway.tatum.io",
+  "https://zcash-mainnet.gateway.tatum.io",
+]);
+
+const config: StrategyConfig = { type: "fallback", rpcUrls: TEST_ENDPOINTS };
+
+// Tatum's gateway whitelists methods, rejecting shielded, address-index, mining
+// and node-admin RPCs with -32601. Those need a full node via ZCASH_RPC_URL.
+const needsFullNode = {
+  skip: hasZcashNodeUrl ? false : "requires ZCASH_RPC_URL (full zebrad node)",
+};
+
+// Anything beyond a handful of calls blows the 5 req/min anonymous budget.
+const needsBudget = { skip: hasTatumApiKey || hasZcashNodeUrl ? false : "requires TATUM_API_KEY" };
+
+// Well-known mainnet data
+const GENESIS_BLOCK_HASH = "00040fe8ec8471911baa1db1266ea15dd06b4a8a5c453883c000b031973dce08";
+const VALID_TRANSPARENT_ADDRESS = "t1Ku2KLyndDPsR32jwnrTMd3yvi9tfFP8ML";
+const INVALID_ADDRESS = "t1InvalidAddressXXXXXXXXXXXXXXXXXXX";
+
+// =============================================================================
+// Offline tests — no network access
+// =============================================================================
+
+describe("ZcashClient - CAIP-2 Chain ID Constants [strong]", () => {
+  it("should expose the mainnet CAIP-2 chain ID", () => {
+    assert.strictEqual(ZCASH_MAINNET, "bip122:00040fe8ec8471911baa1db1266ea15d");
+  });
+
+  it("should expose the testnet CAIP-2 chain ID", () => {
+    assert.strictEqual(ZCASH_TESTNET, "bip122:05a60a92d99d85997cce3b87616c089f");
+  });
+
+  it("should derive the mainnet reference from the genesis block hash", () => {
+    const reference = ZCASH_MAINNET.split(":")[1];
+    assert.strictEqual(
+      reference,
+      GENESIS_BLOCK_HASH.substring(0, 32),
+      "CAIP-2 reference should be the first 32 chars of the genesis hash",
+    );
+  });
+
+  it("should use the bip122 namespace shared with Bitcoin", () => {
+    assert.ok(ZCASH_MAINNET.startsWith("bip122:"), "Zcash is a Bitcoin fork");
+    assert.ok(ZCASH_TESTNET.startsWith("bip122:"), "Zcash is a Bitcoin fork");
+    assert.notStrictEqual(ZCASH_MAINNET, BITCOIN_MAINNET, "Must not collide with Bitcoin");
+  });
+});
+
+describe("ZcashClient - Constructor [strong]", () => {
+  it("should construct with the fallback strategy", () => {
+    const client = new ZcashClient(config);
+    assert.strictEqual(client.getStrategyName(), "fallback");
+  });
+
+  it("should construct with the parallel strategy", () => {
+    const client = new ZcashClient({ type: "parallel", rpcUrls: TEST_ENDPOINTS });
+    assert.strictEqual(client.getStrategyName(), "parallel");
+  });
+
+  it("should expose the configured RPC URLs as strings", () => {
+    const client = new ZcashClient(config);
+    const urls = client.getRpcUrls();
+
+    assert.strictEqual(urls.length, TEST_ENDPOINTS.length);
+    for (const url of urls) {
+      assert.strictEqual(typeof url, "string", "getRpcUrls should return plain strings");
+    }
+  });
+
+  it("should switch strategies via updateStrategy", () => {
+    const client = new ZcashClient(config);
+    client.updateStrategy("race");
+    assert.strictEqual(client.getStrategyName(), "race");
+  });
+});
+
+describe("ZcashClient - Factory Integration [strong]", () => {
+  it("should create a ZcashClient for ZCASH_MAINNET", () => {
+    const client = ClientFactory.createClient(ZCASH_MAINNET, config);
+
+    assert.ok(client instanceof ZcashClient, "Should create ZcashClient instance");
+    assert.strictEqual(client.getStrategyName(), "fallback");
+  });
+
+  it("should create a ZcashClient for ZCASH_TESTNET", () => {
+    const client = ClientFactory.createClient(ZCASH_TESTNET, config);
+    assert.ok(client instanceof ZcashClient, "Should create ZcashClient instance");
+  });
+
+  it("should create a typed ZcashClient via createTypedClient", () => {
+    const client = ClientFactory.createTypedClient(ZCASH_MAINNET, config);
+    assert.ok(client instanceof ZcashClient, "Should create ZcashClient instance");
+  });
+
+  it("should still route Bitcoin chain IDs to BitcoinClient", () => {
+    // Regression guard: Zcash and Bitcoin share the bip122: namespace, so routing
+    // must discriminate on registry membership rather than the prefix.
+    const client = ClientFactory.createClient(BITCOIN_MAINNET, config);
+
+    assert.ok(client instanceof BitcoinClient, "Bitcoin must not be captured by Zcash");
+    assert.ok(!(client instanceof ZcashClient), "Bitcoin must not resolve to ZcashClient");
+  });
+
+  it("should not route Zcash chain IDs to BitcoinClient", () => {
+    const client = ClientFactory.createClient(ZCASH_MAINNET, config);
+    assert.ok(!(client instanceof BitcoinClient), "Zcash must not resolve to BitcoinClient");
+  });
+
+  it("should throw for an unknown bip122 chain ID", () => {
+    assert.throws(
+      () =>
+        ClientFactory.createClient(
+          "bip122:0000000000000000000000000000000f" as typeof ZCASH_MAINNET,
+          config,
+        ),
+      /Unsupported/,
+      "An unregistered bip122 ID should be rejected, not silently routed",
+    );
+  });
+});
+
+describe("ZcashClient - Method Signatures [strong]", () => {
+  const client = new ZcashClient(config);
+
+  const methodGroups: Record<string, string[]> = {
+    "chain and blocks": [
+      "getBlockchainInfo",
+      "getBlockCount",
+      "getBestBlockHash",
+      "getBestBlockHeightAndHash",
+      "getBlockHash",
+      "getBlock",
+      "getBlockHeader",
+      "getDifficulty",
+    ],
+    transactions: ["getRawTransaction", "sendRawTransaction", "getTxOut"],
+    mempool: ["getMempoolInfo", "getRawMempool"],
+    "address index": ["getAddressBalance", "getAddressTxIds", "getAddressUtxos"],
+    shielded: ["zGetTreestate", "zGetSubtreesByIndex", "zValidateAddress", "zListUnifiedReceivers"],
+    mining: [
+      "getBlockTemplate",
+      "submitBlock",
+      "getMiningInfo",
+      "getNetworkSolPs",
+      "getNetworkHashPs",
+      "getBlockSubsidy",
+      "getStandardFee",
+      "generate",
+      "generateToAddress",
+    ],
+    "node and network": [
+      "getInfo",
+      "getDeprecationInfo",
+      "getNetworkInfo",
+      "getPeerInfo",
+      "ping",
+      "addNode",
+      "stop",
+      "validateAddress",
+    ],
+    "chain manipulation": ["invalidateBlock", "reconsiderBlock"],
+  };
+
+  for (const [group, methods] of Object.entries(methodGroups)) {
+    it(`should expose all ${group} methods`, () => {
+      for (const method of methods) {
+        assert.strictEqual(
+          typeof (client as unknown as Record<string, unknown>)[method],
+          "function",
+          `${method} should be a function`,
+        );
+      }
+    });
+  }
+});
+
+// =============================================================================
+// Live tests — real RPC calls, no mocks
+// =============================================================================
+
+describe("ZcashClient - Explorer Chain Methods [strong]", () => {
+  const client = new ZcashClient(config);
+
+  it("should get blockchain info", async () => {
+    const result = await client.getBlockchainInfo();
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assert.ok(result.data, "Should have data");
+    validateBlockchainInfo(result.data);
+    assert.strictEqual(result.data.chain, "main", "Should be mainnet");
+  });
+
+  it("should get the genesis block hash matching the CAIP-2 constant", async () => {
+    const result = await client.getBlockHash(0);
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assert.strictEqual(result.data, GENESIS_BLOCK_HASH, "Should return the genesis hash");
+
+    const reference = ZCASH_MAINNET.split(":")[1];
+    assert.strictEqual(
+      result.data?.substring(0, 32),
+      reference,
+      "Genesis hash prefix should match the CAIP-2 chain ID reference",
+    );
+  });
+
+  it("should get the block count", { ...needsBudget }, async () => {
+    const result = await client.getBlockCount();
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assertNumber(result.data, "block count");
+    assert.ok(result.data > 3_400_000, "Mainnet should be past block 3.4M");
+  });
+
+  it("should get the best block hash", { ...needsBudget }, async () => {
+    const result = await client.getBestBlockHash();
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assertHash(result.data, "best block hash");
+  });
+
+  it("should get the difficulty", { ...needsBudget }, async () => {
+    const result = await client.getDifficulty();
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assertNumber(result.data, "difficulty");
+    assert.ok(result.data > 0, "Difficulty should be positive");
+  });
+});
+
+describe("ZcashClient - Explorer Block Methods [strong]", () => {
+  const client = new ZcashClient(config);
+
+  it("should get the genesis block with verbosity 1", { ...needsBudget }, async () => {
+    // Zcash takes hash_or_height as a string, so a height is passed as "0"
+    const result = await client.getBlock("0", 1);
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assert.ok(result.data, "Should have data");
+    validateBlock(result.data as ZecBlock);
+    assert.strictEqual((result.data as ZecBlock).height, 0, "Should be the genesis block");
+    assert.strictEqual((result.data as ZecBlock).hash, GENESIS_BLOCK_HASH);
+  });
+
+  it("should get a block header", { ...needsBudget }, async () => {
+    const result = await client.getBlockHeader("0", true);
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assert.ok(result.data, "Should have data");
+    validateBlockHeader(result.data as ZecBlockHeader);
+    assert.strictEqual((result.data as ZecBlockHeader).height, 0);
+  });
+
+  it("should get a block with verbosity 2 (full transactions)", { ...needsBudget }, async () => {
+    const result = await client.getBlock("3444000", 2);
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assert.ok(result.data, "Should have data");
+
+    const block = result.data as ZecBlockVerbose;
+    validateBlockHeader(block);
+    assert.ok(Array.isArray(block.tx), "tx should be an array");
+    assert.ok(block.tx.length > 0, "Block should contain transactions");
+    for (const tx of block.tx) {
+      assertObject(tx, "transaction");
+      validateRawTransaction(tx);
+    }
+  });
+
+  it(
+    "should carry Zcash-specific shielded pool fields on a block",
+    { ...needsBudget },
+    async () => {
+      const result = await client.getBlock("3444000", 1);
+
+      assert.strictEqual(result.success, true, "Should succeed");
+      const block = result.data as ZecBlock;
+
+      // finalorchardroot only exists on post-NU5 blocks
+      assertString(block.finalorchardroot, "finalorchardroot");
+      assert.ok(block.trees, "Should carry note commitment tree sizes");
+      assertNumber(block.trees?.sapling?.size, "trees.sapling.size");
+      assertNumber(block.trees?.orchard?.size, "trees.orchard.size");
+    },
+  );
+});
+
+describe("ZcashClient - Explorer Transaction Methods [strong]", () => {
+  const client = new ZcashClient(config);
+
+  it("should get a raw transaction verbosely", { ...needsBudget }, async () => {
+    const mempool = await client.getRawMempool();
+    assert.strictEqual(mempool.success, true, "Should read the mempool");
+
+    const txid = mempool.data?.[0];
+    if (!txid) {
+      // An empty mempool is legitimate, not a failure
+      return;
+    }
+
+    const result = await client.getRawTransaction(txid, 1);
+    assert.strictEqual(result.success, true, "Should succeed");
+    assert.ok(result.data, "Should have data");
+    validateRawTransaction(result.data as ZecRawTransaction);
+  });
+
+  it("should return hex for a raw transaction at verbose 0", { ...needsBudget }, async () => {
+    const mempool = await client.getRawMempool();
+    const txid = mempool.data?.[0];
+    if (!txid) return;
+
+    const result = await client.getRawTransaction(txid, 0);
+    assert.strictEqual(result.success, true, "Should succeed");
+    assertString(result.data, "raw transaction hex");
+  });
+});
+
+describe("ZcashClient - Explorer Mempool Methods [strong]", () => {
+  const client = new ZcashClient(config);
+
+  it("should get mempool info", async () => {
+    const result = await client.getMempoolInfo();
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assert.ok(result.data, "Should have data");
+
+    const info = result.data as ZecMempoolInfo;
+    assertNumber(info.size, "size");
+    assertNumber(info.bytes, "bytes");
+    assertNumber(info.usage, "usage");
+  });
+
+  it("should get the raw mempool as txids", { ...needsBudget }, async () => {
+    const result = await client.getRawMempool();
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assert.ok(Array.isArray(result.data), "Should return an array");
+    for (const txid of result.data ?? []) {
+      assertHash(txid, "mempool txid");
+    }
+  });
+});
+
+describe("ZcashClient - Explorer Utility Methods [strong]", () => {
+  const client = new ZcashClient(config);
+
+  it("should validate a transparent address", { ...needsBudget }, async () => {
+    const result = await client.validateAddress(VALID_TRANSPARENT_ADDRESS);
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    const data = result.data as ZecValidateAddress;
+    assert.strictEqual(data.isvalid, true, "Address should be valid");
+    assert.strictEqual(data.address, VALID_TRANSPARENT_ADDRESS);
+  });
+
+  it("should reject an invalid address", { ...needsBudget }, async () => {
+    const result = await client.validateAddress(INVALID_ADDRESS);
+
+    assert.strictEqual(result.success, true, "Call should succeed");
+    assert.strictEqual(
+      (result.data as ZecValidateAddress).isvalid,
+      false,
+      "Address should be reported invalid",
+    );
+  });
+
+  it("should get network info", { ...needsBudget }, async () => {
+    const result = await client.getNetworkInfo();
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    const info = result.data as ZecNetworkInfo;
+    assertNumber(info.version, "version");
+    assertString(info.subversion, "subversion");
+    assertNumber(info.protocolversion, "protocolversion");
+    assert.ok(Array.isArray(info.networks), "networks should be an array");
+  });
+});
+
+// =============================================================================
+// Methods the public gateway blocks — these need a full zebrad node
+// =============================================================================
+
+describe("ZcashClient - Shielded Pool Methods [strong]", () => {
+  const client = new ZcashClient(config);
+
+  it("should get the treestate at a block", { ...needsFullNode }, async () => {
+    const result = await client.zGetTreestate("3444000");
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assert.ok(result.data, "Should have data");
+    assertHash(result.data.hash, "treestate hash");
+    assertNumber(result.data.height, "treestate height");
+  });
+
+  it("should get sapling subtrees by index", { ...needsFullNode }, async () => {
+    const result = await client.zGetSubtreesByIndex("sapling", 0, 1);
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assert.ok(result.data, "Should have data");
+    assert.ok(Array.isArray(result.data.subtrees), "subtrees should be an array");
+  });
+
+  it("should validate a shielded address", { ...needsFullNode }, async () => {
+    const result = await client.zValidateAddress(VALID_TRANSPARENT_ADDRESS);
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assertBoolean(result.data?.isvalid, "isvalid");
+  });
+});
+
+describe("ZcashClient - Address Index Methods [strong]", () => {
+  const client = new ZcashClient(config);
+
+  it("should get an address balance", { ...needsFullNode }, async () => {
+    const result = await client.getAddressBalance({
+      addresses: [VALID_TRANSPARENT_ADDRESS],
+    });
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assertNumber(result.data?.balance, "balance");
+  });
+
+  it("should get address UTXOs", { ...needsFullNode }, async () => {
+    const result = await client.getAddressUtxos({
+      addresses: [VALID_TRANSPARENT_ADDRESS],
+    });
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assert.ok(Array.isArray(result.data), "Should return an array");
+  });
+
+  it("should get address transaction IDs", { ...needsFullNode }, async () => {
+    const result = await client.getAddressTxIds({
+      addresses: [VALID_TRANSPARENT_ADDRESS],
+      start: 3_400_000,
+      end: 3_400_100,
+    });
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assert.ok(Array.isArray(result.data), "Should return an array");
+  });
+});
+
+describe("ZcashClient - Node Info Methods [strong]", () => {
+  const client = new ZcashClient(config);
+
+  it("should get node info", { ...needsFullNode }, async () => {
+    const result = await client.getInfo();
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assertNumber(result.data?.version, "version");
+    assertString(result.data?.subversion, "subversion");
+  });
+
+  it("should get the block subsidy", { ...needsFullNode }, async () => {
+    const result = await client.getBlockSubsidy();
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assertNumber(result.data?.miner, "miner subsidy");
+  });
+
+  it("should get mining info", { ...needsFullNode }, async () => {
+    const result = await client.getMiningInfo();
+
+    assert.strictEqual(result.success, true, "Should succeed");
+    assertNumber(result.data?.blocks, "blocks");
+  });
+});
+
+describe("ZcashClient - Error Handling [strong]", () => {
+  it("should report failure for an unreachable endpoint", async () => {
+    const client = new ZcashClient({
+      type: "fallback",
+      rpcUrls: ["http://127.0.0.1:1"],
+    });
+
+    const result = await client.getBlockCount();
+
+    assert.strictEqual(result.success, false, "Should fail against a dead endpoint");
+    assert.ok(result.errors, "Should carry error details");
+  });
+
+  it("should return an error for a nonexistent block height", { ...needsBudget }, async () => {
+    const client = new ZcashClient(config);
+    const result = await client.getBlock("999999999", 1);
+
+    assert.strictEqual(result.success, false, "Should fail for an out-of-range height");
+  });
+});
+
+describe("ZcashClient - TxOut [strong]", () => {
+  const client = new ZcashClient(config);
+
+  it("should return null for a spent or unknown output", { ...needsBudget }, async () => {
+    const result = await client.getTxOut(GENESIS_BLOCK_HASH, 0);
+
+    assert.strictEqual(result.success, true, "Call should succeed");
+    // The genesis hash is not a txid, so there is no such output
+    assert.strictEqual(result.data, null, "Unknown outputs should return null");
+  });
+
+  it("should describe a live UTXO when one is available", { ...needsFullNode }, async () => {
+    const mempool = await client.getRawMempool();
+    const txid = mempool.data?.[0];
+    if (!txid) return;
+
+    const result = await client.getTxOut(txid, 0, true);
+    assert.strictEqual(result.success, true, "Should succeed");
+
+    if (result.data) {
+      const txout = result.data as ZecTxOut;
+      assertHash(txout.bestblock, "bestblock");
+      assertNumber(txout.value, "value");
+      assertBoolean(txout.coinbase, "coinbase");
+      assertObject(txout.scriptPubKey, "scriptPubKey");
+    }
+  });
+});

--- a/tests/transport/rpcEndpoint.test.ts
+++ b/tests/transport/rpcEndpoint.test.ts
@@ -1,0 +1,121 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { createTransport } from "../../src/JsonRpcTransport.js";
+import { RpcClient } from "../../src/RpcClient.js";
+import { WebSocketRpcClient } from "../../src/WebSocketRpcClient.js";
+import { NetworkClient } from "../../src/NetworkClient.js";
+import type { RpcEndpoint, StrategyConfig } from "../../src/strategies/requestStrategy.js";
+
+const HTTP_URL = "https://ethereum.publicnode.com";
+const WS_URL = "wss://ethereum.publicnode.com";
+
+describe("RpcEndpoint - createTransport accepts strings and endpoint objects [strong]", () => {
+  it("should create an RpcClient from a plain URL string", () => {
+    const transport = createTransport(HTTP_URL);
+
+    assert.ok(transport instanceof RpcClient, "Should create RpcClient");
+    assert.strictEqual(transport.getUrl(), HTTP_URL, "Should preserve the URL");
+  });
+
+  it("should create an RpcClient from an endpoint object", () => {
+    const transport = createTransport({ url: HTTP_URL, headers: { "x-api-key": "test-key" } });
+
+    assert.ok(transport instanceof RpcClient, "Should create RpcClient");
+    assert.strictEqual(transport.getUrl(), HTTP_URL, "Should unwrap the URL from the object");
+  });
+
+  it("should create an RpcClient from an endpoint object without headers", () => {
+    const transport = createTransport({ url: HTTP_URL });
+
+    assert.ok(transport instanceof RpcClient, "Should create RpcClient");
+    assert.strictEqual(transport.getUrl(), HTTP_URL, "Should unwrap the URL");
+  });
+
+  it("should still detect WebSocket transport from an endpoint object", () => {
+    const transport = createTransport({ url: WS_URL });
+
+    assert.ok(
+      transport instanceof WebSocketRpcClient,
+      "Should create WebSocketRpcClient for a wss endpoint object",
+    );
+    assert.strictEqual(transport.getUrl(), WS_URL, "Should unwrap the URL");
+  });
+});
+
+describe("RpcEndpoint - NetworkClient URL normalization [strong]", () => {
+  it("should return plain strings from getRpcUrls for mixed input", () => {
+    const config: StrategyConfig = {
+      type: "fallback",
+      rpcUrls: [HTTP_URL, { url: "https://cloudflare-eth.com", headers: { "x-api-key": "k" } }],
+    };
+    const client = new NetworkClient(config);
+
+    assert.deepStrictEqual(
+      client.getRpcUrls(),
+      [HTTP_URL, "https://cloudflare-eth.com"],
+      "getRpcUrls should normalize endpoint objects to their URL",
+    );
+  });
+
+  it("should never expose configured headers via getRpcUrls", () => {
+    const config: StrategyConfig = {
+      type: "fallback",
+      rpcUrls: [{ url: HTTP_URL, headers: { "x-api-key": "super-secret" } }],
+    };
+    const client = new NetworkClient(config);
+
+    for (const url of client.getRpcUrls()) {
+      assert.strictEqual(typeof url, "string", "Each entry should be a string");
+      assert.ok(!url.includes("super-secret"), "Header values must not leak into getRpcUrls");
+    }
+  });
+
+  it("should preserve endpoint objects via getRpcEndpoints", () => {
+    const endpoint: RpcEndpoint = { url: HTTP_URL, headers: { "x-api-key": "k" } };
+    const client = new NetworkClient({ type: "fallback", rpcUrls: [endpoint] });
+
+    assert.deepStrictEqual(
+      client.getRpcEndpoints(),
+      [endpoint],
+      "getRpcEndpoints should return the configured endpoints unchanged",
+    );
+  });
+
+  it("should preserve endpoint headers across updateStrategy", () => {
+    const endpoint: RpcEndpoint = { url: HTTP_URL, headers: { "x-api-key": "k" } };
+    const client = new NetworkClient({ type: "fallback", rpcUrls: [endpoint] });
+
+    client.updateStrategy("parallel");
+
+    assert.strictEqual(client.getStrategyName(), "parallel", "Strategy should have switched");
+    assert.deepStrictEqual(
+      client.getRpcEndpoints(),
+      [endpoint],
+      "Endpoint headers should survive a strategy swap",
+    );
+  });
+});
+
+describe("RpcEndpoint - headers are actually transmitted [strong]", () => {
+  // Tatum rejects a bad API key with HTTP 401 but serves anonymous requests, so the
+  // two outcomes distinguish "header sent" from "header dropped" against a real server.
+  const TATUM_URL = "https://zcash-mainnet-zebrad.gateway.tatum.io";
+
+  it("should send configured headers on the request", async () => {
+    const client = new RpcClient(TATUM_URL, { "x-api-key": "definitely-not-a-valid-key" });
+
+    await assert.rejects(
+      () => client.call<number>("getblockcount"),
+      /401/,
+      "An invalid x-api-key should be rejected, proving the header reached the server",
+    );
+  });
+
+  it("should not send an auth header when none is configured", async () => {
+    const client = new RpcClient(TATUM_URL);
+    const result = await client.call<number>("getblockcount");
+
+    assert.strictEqual(typeof result, "number", "Anonymous access should still succeed");
+    assert.ok(result > 0, "Block count should be positive");
+  });
+});


### PR DESCRIPTION
Adds Zcash as a supported network, plus the transport change needed to authenticate against it.

Tracked for explorer adoption in openscan-explorer/explorer#396.

## Zcash targets Zebra, not zcashd

`zcashd` reached its automatic end-of-support halt on **2026-07-18 at block 3417100** — every node shut itself down and refuses to restart, and it does not support the NU6.3/Ironwood upgrade that activated days later. Modelling its ~130-method surface would have targeted software that no longer runs anywhere.

`ZcashClient` therefore covers the ~40 methods [Zebra](https://zebra.zfnd.org/) serves, taken from the `#[method(name = ...)]` attributes in Zebra's source and cross-checked against live mainnet responses from a Zebra 6.2.1 node. Wallet RPCs (`z_sendmany`, `z_getbalance`, …) belong to the separate Zallet daemon and are out of scope.

Chain IDs are CAIP-2, verified live via `getblockhash(0)`:

| Constant | Chain ID | Genesis |
|---|---|---|
| `ZCASH_MAINNET` | `bip122:00040fe8ec8471911baa1db1266ea15d` | `00040fe8…dce08` (`chain: "main"`) |
| `ZCASH_TESTNET` | `bip122:05a60a92d99d85997cce3b87616c089f` | `05a60a92…2c38` (`chain: "test"`) |

Zcash is absent from the [chainagnostic bip122 registry](https://namespaces.chainagnostic.org/bip122/caip2), so these follow the CAIP-4 derivation rule directly — as the Bitcoin constants did.

## ⚠️ Fixes a routing bug affecting Bitcoin

Zcash is a Bitcoin fork and shares the `bip122:` namespace. `isBitcoinNetwork()` matched on that **bare prefix**, so a Zcash chain ID was captured by the Bitcoin guard, missed in `BITCOIN_REGISTRY`, and threw `Unsupported Bitcoin network`.

Both guards now test registry membership:

```ts
function isZcashNetwork(network: SupportedNetwork): network is SupportedZcashChainId {
  return typeof network === "string" && network in ZCASH_REGISTRY;
}
```

Ordering Zcash ahead of Bitcoin would have masked the symptom, but left the prefix check as a trap for the next `bip122` chain (Litecoin, Dogecoin). **Worth reviewing carefully** — it is the one change that touches existing Bitcoin behaviour. There's a regression test asserting the two resolve to distinct clients.

## Transport: per-endpoint headers (additive)

A Tatum API key cannot be passed with the transport as it stood. I tested all four mechanisms:

| Mechanism | Result |
|---|---|
| `x-api-key` header | authenticates (bad key → 401) |
| `Authorization: Bearer` | authenticates (bad key → 401) |
| Key in URL path | **silently ignored** — a fake key still served anonymous traffic |
| `https://user:key@host` | 401 — `fetch` sends Basic, which is rejected |

So the URL-embedding trick that makes Alchemy keys work does not apply, and `RpcClient` hardcoded `Content-Type` as its only header.

```ts
interface RpcEndpoint {
  url: string;
  headers?: Record<string, string>; // HTTP transports only
}

rpcUrls: (string | RpcEndpoint)[]   // plain strings still valid
```

**No breaking change**: `getRpcUrls()` keeps its `string[]` signature by normalising endpoints to their URL, so existing callers are unaffected and headers are never exposed. `getRpcEndpoints()` returns entries verbatim, which also lets `updateStrategy()` preserve headers. Headers are scoped **per endpoint** so a credential is never sent to the other providers in a fallback list. HTTP only — the WS handshake takes no custom headers, and supporting them would mean adopting `ws` and breaking the zero-dependency rule.

## Test gating, and why it looks like that

Tatum is the **only** free no-key Zcash JSON-RPC provider — drpc returns `Unknown network`, BlockPI `unknown host`, lava.build 403s, and PublicNode, Ankr, GetBlock, Blockdaemon, OnFinality, Dwellir, AllThatNode and BlastAPI have no Zcash host at all. Two measured constraints:

- **Its two hosts share one per-IP bucket of 5 req/min.** Verified by alternating rapid-fire requests: 1–3 succeeded, 4–8 all `429`, regardless of host. Listing both buys redundancy, not throughput.
- **It whitelists methods.** Every `z_*` and `getaddress*` call returns `-32601`, as do `getinfo`, `getpeerinfo`, `getmininginfo`, `getblocksubsidy`, `getstandardfee` and `getbestblockheightandhash`.

An API key **raises the rate limit but unlocks nothing** — I tested a real key against all 14 blocked methods and every one still returned `-32601`. The whitelist is fixed, not tier-based.

Hence two independent gates: `TATUM_API_KEY` for rate-limited tests, `ZCASH_RPC_URL` for those needing a full `zebrad`. Both groups were run against a live node to confirm they aren't dead code. The header tests assert transmission without mocking, by checking a bogus key gets 401 while anonymous succeeds.

## Verification

| Check | Result |
|---|---|
| `typecheck` / `build` / `biome check` | clean; **every commit typechecks independently** |
| HTTP suite (with `TATUM_API_KEY`) | 608 tests, 506 pass, 70 fail |
| Baseline on `main` | 549 tests, 456 pass, 70–71 fail |
| WS suite | 9/9 pass |
| Zcash file alone | 41 pass, 0 fail, 10 skipped |

**No new failures** — verified by diffing failing test *names* against `main`, not just counts. The pre-existing failures are unrelated (Hardhat needs a local node; some public-RPC flakiness).

One genuinely stale test I left alone as out of scope: `ClientFactory.test.ts` asserts chain `31337` yields `EthereumClient`, but the registry maps it to `HardhatClient`. It fails on `main` today and is worth a separate fix.

## Also in here

Docs pick up two pre-existing gaps this work ran into: **Solana was entirely undocumented** (merged in 352a5c7, docs commit never written), and the "Adding a New Network" checklists described only the EVM path — pointing at `ChainIdToClient` instead of `NetworkToClient`, omitting the registry and guard steps, and mandating a `tests/ws` file that neither Bitcoin nor Zcash can have.

Zcash has **no WebSocket transport** — Zebra's RPC server is built `.http_only()` — so there is no `tests/ws` directory for it, matching Bitcoin.
